### PR TITLE
chore(ci): unpin netresearch/.github reusables back to @main

### DIFF
--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -10,7 +10,7 @@ permissions: {}
 
 jobs:
   auto-merge:
-    uses: netresearch/.github/.github/workflows/auto-merge-deps.yml@4f6d149347c61a27ce243f5ac8011d6748487341 # main
+    uses: netresearch/.github/.github/workflows/auto-merge-deps.yml@main
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   # Canonical Go pipeline: build + vet + test + golangci-lint + govulncheck + gosec.
   go-check:
-    uses: netresearch/.github/.github/workflows/go-check.yml@4f6d149347c61a27ce243f5ac8011d6748487341 # main
+    uses: netresearch/.github/.github/workflows/go-check.yml@main
     permissions:
       contents: read
       security-events: write
@@ -31,25 +31,25 @@ jobs:
 
   # Workflow-file linter (actionlint) via org reusable.
   lint-workflows:
-    uses: netresearch/.github/.github/workflows/lint-workflows.yml@4f6d149347c61a27ce243f5ac8011d6748487341 # main
+    uses: netresearch/.github/.github/workflows/lint-workflows.yml@main
     permissions:
       contents: read
 
   # Markdown linter via org reusable.
   lint-markdown:
-    uses: netresearch/.github/.github/workflows/lint-markdown.yml@4f6d149347c61a27ce243f5ac8011d6748487341 # main
+    uses: netresearch/.github/.github/workflows/lint-markdown.yml@main
     permissions:
       contents: read
 
   # YAML linter via org reusable.
   lint-yaml:
-    uses: netresearch/.github/.github/workflows/lint-yaml.yml@4f6d149347c61a27ce243f5ac8011d6748487341 # main
+    uses: netresearch/.github/.github/workflows/lint-yaml.yml@main
     permissions:
       contents: read
 
   # Secret scanning via the org reusable.
   gitleaks:
-    uses: netresearch/.github/.github/workflows/gitleaks.yml@4f6d149347c61a27ce243f5ac8011d6748487341 # main
+    uses: netresearch/.github/.github/workflows/gitleaks.yml@main
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,7 +12,7 @@ permissions: {}
 
 jobs:
   analyze:
-    uses: netresearch/.github/.github/workflows/codeql.yml@4f6d149347c61a27ce243f5ac8011d6748487341 # main
+    uses: netresearch/.github/.github/workflows/codeql.yml@main
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -9,7 +9,7 @@ permissions: {}
 
 jobs:
   release:
-    uses: netresearch/.github/.github/workflows/golib-create-release.yml@4f6d149347c61a27ce243f5ac8011d6748487341 # main
+    uses: netresearch/.github/.github/workflows/golib-create-release.yml@main
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -8,7 +8,7 @@ permissions: {}
 
 jobs:
   dependency-review:
-    uses: netresearch/.github/.github/workflows/dependency-review.yml@4f6d149347c61a27ce243f5ac8011d6748487341 # main
+    uses: netresearch/.github/.github/workflows/dependency-review.yml@main
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -8,7 +8,7 @@ permissions: {}
 
 jobs:
   quality-gate:
-    uses: netresearch/.github/.github/workflows/pr-quality.yml@4f6d149347c61a27ce243f5ac8011d6748487341 # main
+    uses: netresearch/.github/.github/workflows/pr-quality.yml@main
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -11,7 +11,7 @@ permissions: {}
 
 jobs:
   analysis:
-    uses: netresearch/.github/.github/workflows/scorecard.yml@4f6d149347c61a27ce243f5ac8011d6748487341 # main
+    uses: netresearch/.github/.github/workflows/scorecard.yml@main
     permissions:
       security-events: write
       id-token: write


### PR DESCRIPTION
The earlier SHA-pin commit treated org-internal reusables like third-party actions. It shouldn't have.

**Pinning \`actions/checkout@<sha>\`**: correct. Upstream is outside our trust boundary; a maintainer-key compromise is a real threat; SHA = immutable guarantee.

**Pinning \`netresearch/.github/...@<sha>\`**: security theater in our setup.

- Same trust boundary — anyone who could force-push the reusables repo already owns the caller repos.
- Reintroduces the duplication the migration just eliminated: every reusable change needs a Renovate PR in every caller.
- Delays security fixes by the Renovate cycle instead of applying immediately.
- \`netresearch/.github:main\` has its own branch protection and CI gates — attacking it is the same bar as attacking any other main branch in the org.

This reverts the internal refs to \`@main\`. External-action SHA pins (\`actions/*\`, \`oven-sh/*\`, \`step-security/*\`, etc.) are **kept** — that's where pinning is actually meaningful.