### PR TITLE
ci: sync with netresearch/.github templates/go-lib

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,3 +36,6 @@ updates:
       interval: weekly
       day: monday
     open-pull-requests-limit: 2
+    groups:
+      devcontainers:
+        patterns: ['*']


### PR DESCRIPTION
Auto-opened by sync-template.sh. Brings this repo back into alignment with the canonical `go-lib` template in `netresearch/.github`.

To keep any diverging files, add their paths to `.github/template.yaml`'s `intentional-drift:` list before merging — otherwise the next sync run will revert them.