### PR TITLE
fix: close worker pool before ranging over results in bulk user ops

### DIFF
--- a/error_paths_test.go
+++ b/error_paths_test.go
@@ -234,12 +234,122 @@ func TestBulkOps_DisabledByDefault(t *testing.T) {
 	})
 }
 
-// Note: Bulk{Create,Modify,Delete}UsersContext with EnableBulkOps=true is
-// deliberately not unit-tested here — the production code path defers
-// pool.Close() while synchronously ranging over pool.Results() which will not
-// terminate until the worker-pool context times out (default 5 min). That
-// represents a product-code concern that is out of scope for this coverage
-// change and needs a separate fix.
+// Regression tests for the deadlock that used to live in the
+// Bulk{Create,Modify,Delete}UsersContext call sites with EnableBulkOps=true:
+// `defer pool.Close()` ran only after the function returned, but the
+// synchronous `for result := range pool.Results()` loop waited for the
+// result channel to close — which only happens inside Close(). The fix is
+// to call Close() in a goroutine after all items are submitted so the
+// channel drains and then closes, letting the range loop terminate.
+//
+// The tests wrap each bulk call in a 2 s timeout context. The underlying
+// LDAP operations fail immediately (no real server), so the calls must
+// return well within the timeout. Previously they would block for 5+ minutes
+// (worker-pool context timeout) and then still hang on the unclosed result
+// channel, i.e. indefinitely.
+
+func newBulkOpsClient(t *testing.T) *LDAP {
+	t.Helper()
+	// Using an example.com hostname bypasses the eager dial in New() so the
+	// test can construct a client without a live LDAP server. All subsequent
+	// operations will fail at GetConnection time — which is fine: we only
+	// care that the bulk call RETURNS rather than hangs.
+	client, err := New(Config{
+		Server:        "ldap://example.com:389",
+		BaseDN:        "dc=example,dc=com",
+		EnableBulkOps: true,
+	}, "cn=admin,dc=example,dc=com", "pass")
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	return client
+}
+
+// fastBulkConfig returns a WorkerPoolConfig with a short operation timeout so
+// the tests don't wait the 5 min default if the fix regresses. Two workers and
+// a small buffer also exercise the "more items than buffer" case.
+func fastBulkConfig() *WorkerPoolConfig {
+	return &WorkerPoolConfig{
+		WorkerCount: 2,
+		BufferSize:  4,
+		Timeout:     500 * time.Millisecond,
+		FailFast:    false,
+	}
+}
+
+func runWithDeadlockGuard(t *testing.T, name string, fn func()) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		fn()
+	}()
+	select {
+	case <-done:
+		// OK
+	case <-time.After(5 * time.Second):
+		t.Fatalf("%s deadlocked: did not return within 5s", name)
+	}
+}
+
+func TestBulkCreateUsersContext_NoDeadlock(t *testing.T) {
+	client := newBulkOpsClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// Submit more items than BufferSize to make sure we don't deadlock when
+	// workers block on a full result channel.
+	users := make([]FullUser, 10)
+	for i := range users {
+		users[i] = FullUser{CN: "user"}
+	}
+
+	runWithDeadlockGuard(t, "BulkCreateUsersContext", func() {
+		results, err := client.BulkCreateUsersContext(ctx, users, "pw", fastBulkConfig())
+		// We don't assert on err — the point is that the call RETURNS.
+		// Operations will have failed (no real LDAP server) but they should
+		// either show up as errored results or be skipped via submission
+		// failures; either way the function must return.
+		_ = results
+		_ = err
+	})
+}
+
+func TestBulkModifyUsersContext_NoDeadlock(t *testing.T) {
+	client := newBulkOpsClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	mods := make([]UserModification, 10)
+	for i := range mods {
+		mods[i] = UserModification{
+			DN:         "cn=x,dc=example,dc=com",
+			Attributes: map[string][]string{"description": {"d"}},
+		}
+	}
+
+	runWithDeadlockGuard(t, "BulkModifyUsersContext", func() {
+		results, err := client.BulkModifyUsersContext(ctx, mods, fastBulkConfig())
+		_ = results
+		_ = err
+	})
+}
+
+func TestBulkDeleteUsersContext_NoDeadlock(t *testing.T) {
+	client := newBulkOpsClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	dns := make([]string, 10)
+	for i := range dns {
+		dns[i] = "cn=x,dc=example,dc=com"
+	}
+
+	runWithDeadlockGuard(t, "BulkDeleteUsersContext", func() {
+		results, err := client.BulkDeleteUsersContext(ctx, dns, fastBulkConfig())
+		_ = results
+		_ = err
+	})
+}
 
 // =============================================================================
 // groups.go — FindGroupByDN/FindGroups error paths

--- a/users.go
+++ b/users.go
@@ -1470,7 +1470,6 @@ func (l *LDAP) BulkCreateUsersContext(ctx context.Context, users []FullUser, pas
 
 	// Create worker pool
 	pool := NewWorkerPool[FullUser](l, config)
-	defer pool.Close()
 
 	// Submit work items - continue on submission failures
 	submissionFailures := 0
@@ -1491,6 +1490,15 @@ func (l *LDAP) BulkCreateUsersContext(ctx context.Context, users []FullUser, pas
 				slog.String("error", err.Error()))
 		}
 	}
+
+	// Close the pool in a goroutine once all items are submitted. Close()
+	// closes the work channel, waits for workers to finish draining, then
+	// closes the result channel — which lets the range loop below terminate.
+	// Running it in a goroutine avoids a deadlock when the number of work
+	// items exceeds the result-channel buffer: workers block on the full
+	// buffer, wg.Wait() never returns, so if we called Close() before the
+	// range loop the range would never start.
+	go pool.Close()
 
 	// Collect results
 	var results []WorkResult[FullUser]
@@ -1558,7 +1566,6 @@ func (l *LDAP) BulkModifyUsersContext(ctx context.Context, modifications []UserM
 
 	// Create worker pool
 	pool := NewWorkerPool[UserModification](l, config)
-	defer pool.Close()
 
 	// Submit work items
 	for i, mod := range modifications {
@@ -1604,6 +1611,11 @@ func (l *LDAP) BulkModifyUsersContext(ctx context.Context, modifications []UserM
 				slog.String("error", err.Error()))
 		}
 	}
+
+	// Close the pool once all items are submitted so the result channel
+	// will be closed after workers drain. See BulkCreateUsersContext for
+	// the full rationale on why this must run in a goroutine.
+	go pool.Close()
 
 	// Collect results
 	var results []WorkResult[UserModification]
@@ -1659,7 +1671,6 @@ func (l *LDAP) BulkDeleteUsersContext(ctx context.Context, dns []string, config 
 
 	// Create worker pool
 	pool := NewWorkerPool[string](l, config)
-	defer pool.Close()
 
 	// Submit work items
 	for i, dn := range dns {
@@ -1677,6 +1688,11 @@ func (l *LDAP) BulkDeleteUsersContext(ctx context.Context, dns []string, config 
 				slog.String("error", err.Error()))
 		}
 	}
+
+	// Close the pool once all items are submitted so the result channel
+	// will be closed after workers drain. See BulkCreateUsersContext for
+	// the full rationale on why this must run in a goroutine.
+	go pool.Close()
 
 	// Collect results
 	var results []WorkResult[string]


### PR DESCRIPTION
## Summary

Fixes a latent deadlock in `BulkCreateUsersContext`, `BulkModifyUsersContext`, and `BulkDeleteUsersContext` (and their non-context wrappers) when `EnableBulkOps=true`.

Closes #144.

## The bug

All three functions had this pattern:

```go
pool := NewWorkerPool[T](l, config)
defer pool.Close()
// ... Submit items ...
for result := range pool.Results() { ... }
```

[`WorkerPool.Close()`](https://github.com/netresearch/simple-ldap-go/blob/main/concurrency.go#L230-L235) is the only place that closes `resultChan`. `defer` means the range loop waited forever for a channel that would never close while the enclosing function was still running. The pool's 5-minute context timeout does not help — workers exit when it fires, but the results channel remains open, so the caller hangs indefinitely.

This was already acknowledged in [`error_paths_test.go`](https://github.com/netresearch/simple-ldap-go/blob/main/error_paths_test.go#L237-L242) where the tests were skipped with a note saying it "needs a separate fix."

## The fix

Call `pool.Close()` in a goroutine after all items are submitted, before ranging over results. A goroutine (rather than a synchronous call before the range loop) is required because workers block on a full result-channel buffer when the number of items exceeds `BufferSize` — so `Close()`'s `wg.Wait()` would never return if it ran before the range loop started draining.

## Regression tests

Three new tests in `error_paths_test.go`:

- `TestBulkCreateUsersContext_NoDeadlock`
- `TestBulkModifyUsersContext_NoDeadlock`
- `TestBulkDeleteUsersContext_NoDeadlock`

Each submits 10 items through a 4-slot buffer with 2 workers (to exercise the full-buffer path) and wraps the call in a 5-second deadlock guard.

Verified genuine by temporarily reverting `users.go` and rerunning:

```
--- FAIL: TestBulkCreateUsersContext_NoDeadlock (5.00s)
--- FAIL: TestBulkModifyUsersContext_NoDeadlock (5.00s)
--- FAIL: TestBulkDeleteUsersContext_NoDeadlock (5.00s)
```

With the fix in place, all three pass in under 10 ms.

## Test plan

- [x] `go test -timeout 180s ./...` passes
- [x] `go test -race` passes on the new tests
- [x] `golangci-lint run` clean
- [x] Regression tests fail on pre-fix code (verified by `git stash` + re-run)
- [x] Full suite still passes with fix applied