### PR TITLE
fix: disable integration tests on main until suite is fixed

### DIFF
--- a/.github/template.yaml
+++ b/.github/template.yaml
@@ -4,4 +4,6 @@
 template: go-lib
 intentional-drift:
 - path: .github/workflows/ci.yml
-  reason: "coverage-threshold at 77% \u2014 transitional until coverage reaches 80%; the remaining gap requires an in-repo LDAP test fixture (testcontainers currently gated behind the 'integration' build tag and not exercised by go-check.yml)"
+  reason: "coverage-threshold 77 transitional (2.7pp to 80% needs integration tests\
+    \ \u2014 see #140); enable-integration-tests disabled until pre-existing test\
+    \ failures are fixed (see #147)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
       enable-fuzz: true
       enable-license-check: true
       enable-codecov: true
-      enable-integration-tests: true
       coverage-threshold: 77
     permissions:
       contents: read


### PR DESCRIPTION
Integration tests surface pre-existing failures on main (assertion bugs, test-data issues, objectClass schema mismatch vs test container). They ran for the first time via #145 and CI has been red on main since. Rolling back the toggle until the suite is cleaned up.

Follow-up tracked as #147 (filed in this PR).