### PR TITLE
fix(users): map SAMAccountName -> uid on non-AD CreateUser

### DIFF
--- a/error_paths_test.go
+++ b/error_paths_test.go
@@ -170,6 +170,20 @@ func TestCreateUser_CancelledContext(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestCreateUser_InvalidSAMAccountName(t *testing.T) {
+	client := newExampleClient(t)
+	// Contains a space, which ValidateSAMAccountName rejects.
+	bad := "bad user"
+	_, err := client.CreateUser(FullUser{
+		CN:             "Bad User",
+		FirstName:      "Bad",
+		LastName:       "User",
+		SAMAccountName: &bad,
+	}, "password")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "invalid sAMAccountName")
+}
+
 func TestModifyUser_ConnectionError(t *testing.T) {
 	client := newExampleClient(t)
 	err := client.ModifyUser("cn=x,dc=example,dc=com", map[string][]string{

--- a/users.go
+++ b/users.go
@@ -1121,6 +1121,12 @@ func (l *LDAP) CreateUserContext(ctx context.Context, user FullUser, password st
 			return "<nil>"
 		}()))
 
+	if user.SAMAccountName != nil {
+		if err := ValidateSAMAccountName(*user.SAMAccountName); err != nil {
+			return "", fmt.Errorf("invalid sAMAccountName: %w", err)
+		}
+	}
+
 	if user.ObjectClasses == nil {
 		// Default to the Active Directory "user" object chain on AD, and to the
 		// OpenLDAP-compatible inetOrgPerson chain otherwise. Callers can still
@@ -1199,6 +1205,12 @@ func (l *LDAP) CreateUserContext(ctx context.Context, user FullUser, password st
 		if user.SAMAccountName != nil {
 			req.Attribute("sAMAccountName", []string{*user.SAMAccountName})
 		}
+	} else if user.SAMAccountName != nil {
+		// inetOrgPerson has no sAMAccountName. Store the value in `uid`,
+		// which FindUserBySAMAccountName falls back to when the AD-only
+		// attribute isn't present. Without this, users created with a
+		// SAMAccountName on OpenLDAP are silently unfindable by it.
+		req.Attribute("uid", []string{*user.SAMAccountName})
 	}
 
 	if user.Description != nil {

--- a/users_integration_test.go
+++ b/users_integration_test.go
@@ -4,6 +4,7 @@ package ldap
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -146,4 +147,55 @@ func TestUserCRUDOperationsIntegration(t *testing.T) {
 			t.Logf("DeleteUser cleanup result: %v", err)
 		}
 	})
+}
+
+// TestCreateUserWithSAMAccountNameOnOpenLDAP is the regression test for
+// issue #153: CreateUser on a non-AD directory must round-trip via
+// FindUserBySAMAccountName. The AD-only sAMAccountName attribute is
+// unusable on inetOrgPerson, so the implementation now falls back to
+// storing the value in `uid` — which is exactly what FindUserBy
+// SAMAccountName falls back to on non-AD schemas.
+func TestCreateUserWithSAMAccountNameOnOpenLDAP(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	tc := SetupTestContainer(t)
+	defer tc.Close(t)
+
+	client := tc.GetLDAPClient(t)
+
+	sam := "regress153"
+	testUser := FullUser{
+		CN:             "Regress 153",
+		FirstName:      "Regress",
+		LastName:       "OneFiftyThree",
+		SAMAccountName: &sam,
+		UserAccountControl: UAC{
+			NormalAccount: true,
+		},
+	}
+
+	dn, err := client.CreateUser(testUser, "password123")
+	require.NoError(t, err, "CreateUser on OpenLDAP must succeed when SAMAccountName is supplied")
+	require.NotEmpty(t, dn)
+
+	// Clean up on any exit — even assertion failures below.
+	defer func() {
+		if delErr := client.DeleteUser(dn); delErr != nil {
+			t.Logf("cleanup DeleteUser: %v", delErr)
+		}
+	}()
+
+	// The round-trip: the user we just created must be findable by
+	// SAMAccountName. Before the fix this returned ErrUserNotFound
+	// because `uid` was never populated on the non-AD code path.
+	found, err := client.FindUserBySAMAccountName(sam)
+	require.NoError(t, err, "FindUserBySAMAccountName must find the user we just created")
+	require.NotNil(t, found)
+	// OpenLDAP normalizes attribute-type case in returned DNs (e.g.
+	// `cn=` vs the `CN=` the client constructs), so compare case-
+	// insensitively.
+	assert.True(t, strings.EqualFold(dn, found.DN()),
+		"DN mismatch: created=%q found=%q", dn, found.DN())
+	assert.Equal(t, sam, found.SAMAccountName)
 }


### PR DESCRIPTION
## Summary

Closes [#153](https://github.com/netresearch/simple-ldap-go/issues/153) (Gemini HIGH review follow-up on [#151](https://github.com/netresearch/simple-ldap-go/pull/151)).

Before this change, \`CreateUser\` on OpenLDAP (\`IsActiveDirectory=false\`) silently dropped \`FullUser.SAMAccountName\` because the attribute was emitted only inside the AD-gated block. \`FindUserBySAMAccountName\`'s non-AD fallback searches on \`uid\`, so a user created with a SAMAccountName value was unfindable by that value — the write succeeded but the round-trip returned \`ErrUserNotFound\`.

### Fix

1. \`users.go\` — add the \`else if user.SAMAccountName != nil\` branch on the non-AD path that persists the value in \`uid\` (inetOrgPerson has no \`sAMAccountName\` attribute).
2. \`users.go\` — validate \`SAMAccountName\` at the \`CreateUser\` entry point via the existing \`ValidateSAMAccountName\` helper, matching \`FindUserBySAMAccountName\`'s entry-point validation.

### Regression test

\`TestCreateUserWithSAMAccountNameOnOpenLDAP\` in \`users_integration_test.go\` runs against the OpenLDAP testcontainer:

1. Create a user with a SAMAccountName.
2. Look up the same user by \`FindUserBySAMAccountName\` — must succeed and return the user.

Without the fix this test returns \`ErrUserNotFound\`; with the fix it passes (verified locally below).

## Test plan

- [x] \`go test -tags=integration -run TestCreateUserWithSAMAccountNameOnOpenLDAP -timeout 5m ./...\` passes locally (8.3 s).
- [x] \`go test -short ./...\` — full unit suite still green (55 s).
- [x] AD code path unchanged (sAMAccountName still goes to the AD \`sAMAccountName\` attribute + the same accountExpires/userAccountControl group).