### PR TITLE
fix(dependabot): remove ecosystems without manifests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,13 @@ updates:
     groups:
       github-actions:
         patterns: ['*']
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 3
+    groups:
+      docker:
+        patterns: ['*']

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,33 +19,3 @@ updates:
     groups:
       github-actions:
         patterns: ['*']
-
-  - package-ecosystem: docker
-    directory: /
-    schedule:
-      interval: weekly
-      day: monday
-    open-pull-requests-limit: 3
-    groups:
-      docker:
-        patterns: ['*']
-
-  - package-ecosystem: npm
-    directory: /
-    schedule:
-      interval: weekly
-      day: monday
-    open-pull-requests-limit: 5
-    groups:
-      npm:
-        patterns: ['*']
-
-  - package-ecosystem: devcontainers
-    directory: /
-    schedule:
-      interval: weekly
-      day: monday
-    open-pull-requests-limit: 2
-    groups:
-      devcontainers:
-        patterns: ['*']


### PR DESCRIPTION
## Summary

Remove the `npm`, `docker`, and `devcontainers` ecosystems from `.github/dependabot.yml`. None of these are applicable:

- No `package.json` -> npm Dependabot job errors weekly with `/package.json not found`
- No `Dockerfile` -> docker has nothing to update
- No `.devcontainer/` -> devcontainers has nothing to update

The failing npm job turns main red on every weekly Dependabot schedule.

## Test plan

- [x] Confirmed no `package.json`, `Dockerfile`, or `.devcontainer/` in repo
- [x] Weekly Dependabot job log confirms `dependency_file_not_found: /package.json not found`
- Actions will verify yamllint/actionlint accept the trimmed config