### PR TITLE
feat(user): surface more user attributes on User struct

### DIFF
--- a/users.go
+++ b/users.go
@@ -27,8 +27,21 @@ var (
 	// accountExpiresNever represents the value for accounts that never expire in Active Directory.
 	accountExpiresNever uint64 = 0x7FFFFFFFFFFFFFFF
 
-	// userFields contains the standard LDAP attributes retrieved for user objects.
-	userFields = []string{"memberOf", "cn", "sAMAccountName", "mail", "userAccountControl", "description", "lastLogonTimestamp"}
+	// userFields contains the standard LDAP attributes retrieved for user
+	// objects. The list is shared between AD and OpenLDAP searches — servers
+	// silently ignore attribute names they do not know.
+	userFields = []string{
+		// Core identity
+		"memberOf", "cn", "sAMAccountName", "uid", "mail",
+		"userAccountControl", "description", "lastLogonTimestamp",
+		// Extended identity / org
+		"givenName", "sn", "displayName", "title", "department", "company",
+		"manager", "telephoneNumber", "mobile", "physicalDeliveryOfficeName",
+		// Security posture
+		"accountExpires", "pwdLastSet", "lockoutTime",
+		// Audit
+		"whenCreated", "whenChanged",
+	}
 )
 
 // User represents an LDAP user object with common attributes.
@@ -44,6 +57,43 @@ type User struct {
 	Mail *string
 	// LastLogon contains the timestamp of the last logon (from lastLogonTimestamp, replicated).
 	LastLogon int64
+	// GivenName is the user's first (given) name.
+	GivenName string
+	// Surname is the user's last (family) name (LDAP `sn`).
+	Surname string
+	// DisplayName is the user's presentation name — may differ from CN.
+	DisplayName string
+	// Title is the user's job title.
+	Title string
+	// Department names the user's department.
+	Department string
+	// Company names the user's employer organisation.
+	Company string
+	// ManagerDN is the distinguished name of the user's manager, or "" when unset.
+	ManagerDN string
+	// TelephoneNumber is the user's office phone.
+	TelephoneNumber string
+	// Mobile is the user's mobile phone.
+	Mobile string
+	// Office is a human-readable office location (physicalDeliveryOfficeName).
+	Office string
+	// AccountExpires is the Unix-seconds timestamp at which the account expires,
+	// 0 when unset, or -1 for "never" (AD's 9223372036854775807 / 0).
+	AccountExpires int64
+	// PwdLastSet is the Unix-seconds timestamp at which the user last changed
+	// their password, 0 when unset. When the AD value is 0 it means the user
+	// must change password at next logon; callers should consult MustChangePassword.
+	PwdLastSet int64
+	// MustChangePassword is true when pwdLastSet is 0 in AD (forces change
+	// on next logon). OpenLDAP servers always report false.
+	MustChangePassword bool
+	// LockoutTime is the Unix-seconds timestamp of the most recent lockout,
+	// 0 when the account is not currently locked.
+	LockoutTime int64
+	// WhenCreated is the Unix-seconds timestamp at which the entry was created.
+	WhenCreated int64
+	// WhenChanged is the Unix-seconds timestamp at which the entry was last modified.
+	WhenChanged int64
 	// Groups contains a list of distinguished names (DNs) of groups the user belongs to.
 	Groups []string
 }
@@ -74,14 +124,33 @@ func userFromEntry(entry *ldap.Entry) (*User, error) {
 
 	mail := getFirstNonEmptyAttribute(entry, "mail")
 
+	pwdLastSet := parseFileTimeSeconds(entry.GetAttributeValue("pwdLastSet"))
+	mustChange := entry.GetAttributeValue("pwdLastSet") == "0"
+
 	return &User{
-		Object:         objectFromEntry(entry),
-		Enabled:        enabled,
-		SAMAccountName: samAccountName,
-		Description:    entry.GetAttributeValue("description"),
-		Mail:           mail,
-		LastLogon:      parseLastLogonTimestamp(entry.GetAttributeValue("lastLogonTimestamp")),
-		Groups:         entry.GetAttributeValues("memberOf"),
+		Object:             objectFromEntry(entry),
+		Enabled:            enabled,
+		SAMAccountName:     samAccountName,
+		Description:        entry.GetAttributeValue("description"),
+		Mail:               mail,
+		LastLogon:          parseLastLogonTimestamp(entry.GetAttributeValue("lastLogonTimestamp")),
+		GivenName:          entry.GetAttributeValue("givenName"),
+		Surname:            entry.GetAttributeValue("sn"),
+		DisplayName:        entry.GetAttributeValue("displayName"),
+		Title:              entry.GetAttributeValue("title"),
+		Department:         entry.GetAttributeValue("department"),
+		Company:            entry.GetAttributeValue("company"),
+		ManagerDN:          entry.GetAttributeValue("manager"),
+		TelephoneNumber:    entry.GetAttributeValue("telephoneNumber"),
+		Mobile:             entry.GetAttributeValue("mobile"),
+		Office:             entry.GetAttributeValue("physicalDeliveryOfficeName"),
+		AccountExpires:     parseAccountExpires(entry.GetAttributeValue("accountExpires")),
+		PwdLastSet:         pwdLastSet,
+		MustChangePassword: mustChange,
+		LockoutTime:        parseFileTimeSeconds(entry.GetAttributeValue("lockoutTime")),
+		WhenCreated:        parseGeneralizedTime(entry.GetAttributeValue("whenCreated")),
+		WhenChanged:        parseGeneralizedTime(entry.GetAttributeValue("whenChanged")),
+		Groups:             entry.GetAttributeValues("memberOf"),
 	}, nil
 }
 
@@ -398,7 +467,7 @@ func (l *LDAP) FindUserBySAMAccountNameContext(ctx context.Context, sAMAccountNa
 			Scope:        ldap.ScopeWholeSubtree,
 			DerefAliases: ldap.NeverDerefAliases,
 			Filter:       filter,
-			Attributes:   []string{"memberOf", "cn", "uid", "mail", "description"}, // OpenLDAP compatible attributes
+			Attributes:   userFields, // shared AD + OpenLDAP attribute list (unknown attrs are ignored by the server)
 		})
 		if err != nil {
 			l.logger.Error("user_search_openldap_failed",
@@ -666,7 +735,7 @@ func (l *LDAP) FindUserByMailContext(ctx context.Context, mail string) (user *Us
 		Scope:        ldap.ScopeWholeSubtree,
 		DerefAliases: ldap.NeverDerefAliases,
 		Filter:       filter,
-		Attributes:   []string{"memberOf", "cn", "sAMAccountName", "uid", "mail", "userAccountControl", "description"}, // Include both AD and OpenLDAP attributes
+		Attributes:   userFields, // shared AD + OpenLDAP attribute list
 	})
 	if err != nil {
 		l.logger.Error("user_search_by_mail_failed",
@@ -819,7 +888,7 @@ func (l *LDAP) FindUsersContext(ctx context.Context) (users []User, err error) {
 		Scope:        ldap.ScopeWholeSubtree,
 		DerefAliases: ldap.NeverDerefAliases,
 		Filter:       filter,
-		Attributes:   []string{"memberOf", "cn", "sAMAccountName", "uid", "mail", "userAccountControl", "description"}, // Include both AD and OpenLDAP attributes
+		Attributes:   userFields, // shared AD + OpenLDAP attribute list
 	})
 	if err != nil {
 		l.logger.Error("user_list_search_failed",

--- a/users.go
+++ b/users.go
@@ -77,8 +77,11 @@ type User struct {
 	Mobile string
 	// Office is a human-readable office location (physicalDeliveryOfficeName).
 	Office string
-	// AccountExpires is the Unix-seconds timestamp at which the account expires,
-	// 0 when unset, or -1 for "never" (AD's 9223372036854775807 / 0).
+	// AccountExpires is the Unix-seconds timestamp at which the account expires.
+	// Three-value meaning:
+	//   0  — not set (no expiry recorded on the entry)
+	//   -1 — never expires (AD's sentinel 9223372036854775807 = 0x7FFFFFFFFFFFFFFF)
+	//   >0 — concrete expiry timestamp in Unix seconds.
 	AccountExpires int64
 	// PwdLastSet is the Unix-seconds timestamp at which the user last changed
 	// their password, 0 when unset. When the AD value is 0 it means the user

--- a/users_from_entry_test.go
+++ b/users_from_entry_test.go
@@ -1,0 +1,168 @@
+package ldap
+
+import (
+	"testing"
+
+	"github.com/go-ldap/ldap/v3"
+)
+
+// TestUserFromEntry_ADFull exercises userFromEntry against a typical
+// Active Directory entry populated with every extended attribute added
+// in this PR. Keeps coverage on the AD branch + the field-mapping code.
+func TestUserFromEntry_ADFull(t *testing.T) {
+	t.Parallel()
+
+	entry := &ldap.Entry{
+		DN: "CN=Jane Doe,OU=Engineering,DC=example,DC=com",
+		Attributes: []*ldap.EntryAttribute{
+			{Name: "cn", Values: []string{"Jane Doe"}},
+			{Name: "sAMAccountName", Values: []string{"jdoe"}},
+			{Name: "userAccountControl", Values: []string{"512"}}, // normal, enabled
+			{Name: "description", Values: []string{"Principal engineer"}},
+			{Name: "mail", Values: []string{"jdoe@example.com"}},
+			{Name: "lastLogonTimestamp", Values: []string{"133253376000000000"}},
+			{Name: "givenName", Values: []string{"Jane"}},
+			{Name: "sn", Values: []string{"Doe"}},
+			{Name: "displayName", Values: []string{"Jane Doe (Eng)"}},
+			{Name: "title", Values: []string{"Principal Engineer"}},
+			{Name: "department", Values: []string{"Engineering"}},
+			{Name: "company", Values: []string{"Example Corp"}},
+			{Name: "manager", Values: []string{"CN=Alex Lead,OU=Engineering,DC=example,DC=com"}},
+			{Name: "telephoneNumber", Values: []string{"+1-555-0100"}},
+			{Name: "mobile", Values: []string{"+1-555-0101"}},
+			{Name: "physicalDeliveryOfficeName", Values: []string{"HQ-2F"}},
+			{Name: "accountExpires", Values: []string{"9223372036854775807"}}, // never
+			{Name: "pwdLastSet", Values: []string{"133253376000000000"}},
+			{Name: "lockoutTime", Values: []string{"0"}},
+			{Name: "whenCreated", Values: []string{"20230101120000.0Z"}},
+			{Name: "whenChanged", Values: []string{"20240601090000Z"}},
+			{Name: "memberOf", Values: []string{"CN=Admins,DC=example,DC=com", "CN=Devs,DC=example,DC=com"}},
+		},
+	}
+
+	u, err := userFromEntry(entry)
+	if err != nil {
+		t.Fatalf("userFromEntry returned error: %v", err)
+	}
+
+	if !u.Enabled {
+		t.Errorf("Enabled = false, want true (uac=512)")
+	}
+	if u.SAMAccountName != "jdoe" {
+		t.Errorf("SAMAccountName = %q, want jdoe", u.SAMAccountName)
+	}
+	if u.Description != "Principal engineer" {
+		t.Errorf("Description = %q", u.Description)
+	}
+	if u.Mail == nil || *u.Mail != "jdoe@example.com" {
+		t.Errorf("Mail = %v, want jdoe@example.com", u.Mail)
+	}
+	if u.LastLogon != 1680864000 {
+		t.Errorf("LastLogon = %d, want 1680864000", u.LastLogon)
+	}
+	if u.GivenName != "Jane" || u.Surname != "Doe" || u.DisplayName != "Jane Doe (Eng)" {
+		t.Errorf("identity fields mismatched: given=%q sn=%q display=%q",
+			u.GivenName, u.Surname, u.DisplayName)
+	}
+	if u.Title != "Principal Engineer" || u.Department != "Engineering" || u.Company != "Example Corp" {
+		t.Errorf("org fields mismatched: title=%q dept=%q company=%q",
+			u.Title, u.Department, u.Company)
+	}
+	if u.ManagerDN != "CN=Alex Lead,OU=Engineering,DC=example,DC=com" {
+		t.Errorf("ManagerDN = %q", u.ManagerDN)
+	}
+	if u.TelephoneNumber != "+1-555-0100" || u.Mobile != "+1-555-0101" {
+		t.Errorf("phone fields mismatched: tel=%q mob=%q", u.TelephoneNumber, u.Mobile)
+	}
+	if u.Office != "HQ-2F" {
+		t.Errorf("Office = %q", u.Office)
+	}
+	if u.AccountExpires != -1 {
+		t.Errorf("AccountExpires = %d, want -1 (never)", u.AccountExpires)
+	}
+	if u.PwdLastSet != 1680864000 {
+		t.Errorf("PwdLastSet = %d, want 1680864000", u.PwdLastSet)
+	}
+	if u.MustChangePassword {
+		t.Errorf("MustChangePassword = true, want false (pwdLastSet != 0)")
+	}
+	if u.LockoutTime != 0 {
+		t.Errorf("LockoutTime = %d, want 0", u.LockoutTime)
+	}
+	if u.WhenCreated == 0 {
+		t.Errorf("WhenCreated = 0, expected a parsed timestamp")
+	}
+	if u.WhenChanged == 0 {
+		t.Errorf("WhenChanged = 0, expected a parsed timestamp")
+	}
+	if got := len(u.Groups); got != 2 {
+		t.Errorf("Groups length = %d, want 2", got)
+	}
+}
+
+// TestUserFromEntry_OpenLDAP covers the openldap branch (no
+// userAccountControl) and the "must change password" pwdLastSet=0
+// case. Most identity fields are absent in this scenario — verifies
+// they default to zero values cleanly.
+func TestUserFromEntry_OpenLDAP(t *testing.T) {
+	t.Parallel()
+
+	entry := &ldap.Entry{
+		DN: "uid=alice,ou=people,dc=example,dc=com",
+		Attributes: []*ldap.EntryAttribute{
+			{Name: "cn", Values: []string{"Alice Demo"}},
+			{Name: "uid", Values: []string{"alice"}},
+			{Name: "mail", Values: []string{"alice@example.com"}},
+			{Name: "description", Values: []string{""}},
+			{Name: "pwdLastSet", Values: []string{"0"}},
+		},
+	}
+
+	u, err := userFromEntry(entry)
+	if err != nil {
+		t.Fatalf("userFromEntry returned error: %v", err)
+	}
+
+	if !u.Enabled {
+		t.Errorf("OpenLDAP user should default Enabled=true")
+	}
+	if u.SAMAccountName != "alice" {
+		t.Errorf("SAMAccountName = %q, want alice (uid fallback)", u.SAMAccountName)
+	}
+	if !u.MustChangePassword {
+		t.Errorf("MustChangePassword = false, want true (pwdLastSet=0)")
+	}
+	if u.GivenName != "" || u.Surname != "" || u.Title != "" {
+		t.Errorf("identity fields should be empty for this entry")
+	}
+	if u.AccountExpires != 0 {
+		t.Errorf("AccountExpires = %d, want 0 (unset)", u.AccountExpires)
+	}
+	if u.WhenCreated != 0 || u.WhenChanged != 0 {
+		t.Errorf("audit timestamps should be 0 when absent: created=%d changed=%d",
+			u.WhenCreated, u.WhenChanged)
+	}
+}
+
+// TestUserFromEntry_CNFallback exercises the OpenLDAP sAMAccountName
+// fallback path where uid is missing — CN is used instead. The code
+// path is otherwise uncovered.
+func TestUserFromEntry_CNFallback(t *testing.T) {
+	t.Parallel()
+
+	entry := &ldap.Entry{
+		DN: "cn=svc-account,ou=services,dc=example,dc=com",
+		Attributes: []*ldap.EntryAttribute{
+			{Name: "cn", Values: []string{"svc-account"}},
+		},
+	}
+
+	u, err := userFromEntry(entry)
+	if err != nil {
+		t.Fatalf("userFromEntry returned error: %v", err)
+	}
+
+	if u.SAMAccountName != "svc-account" {
+		t.Errorf("SAMAccountName = %q, want svc-account (cn fallback)", u.SAMAccountName)
+	}
+}

--- a/utils.go
+++ b/utils.go
@@ -136,11 +136,15 @@ func parseFileTimeSeconds(value string) int64 {
 const accountExpiresNeverSigned int64 = 0x7FFFFFFFFFFFFFFF
 
 // parseAccountExpires parses the Active Directory accountExpires
-// attribute. Returns:
+// attribute. The directory transmits the value as a base-10 decimal
+// string (this function does NOT accept 0x-prefixed hex input); the
+// constant 0x7FFFFFFFFFFFFFFF is given in hex only for reference and
+// equals the decimal sentinel 9223372036854775807. Returns:
 //
-//   - 0 when unset or "0" (interpreted as "no expiry specified")
+//   - 0 when the value is empty or "0" (interpreted as "no expiry
+//     specified")
 //   - -1 when equal to the AD "never expires" sentinel
-//     (0x7FFFFFFFFFFFFFFF / 9223372036854775807)
+//     (decimal 9223372036854775807)
 //   - Otherwise the Unix-seconds timestamp of expiry.
 func parseAccountExpires(value string) int64 {
 	if value == "" || value == "0" {
@@ -160,24 +164,35 @@ func parseAccountExpires(value string) int64 {
 }
 
 // parseGeneralizedTime parses an LDAP GeneralizedTime string
-// (RFC 4517 §3.3.13) into Unix seconds. Accepts the common AD
-// variants: "YYYYMMDDHHMMSS.fZ" and "YYYYMMDDHHMMSSZ". Returns 0
-// when parsing fails so callers can treat it as "unknown".
+// (RFC 4517 §3.3.13) into Unix seconds. Accepts the two common AD
+// variants:
+//
+//   - "YYYYMMDDHHMMSSZ" (no fraction)
+//   - "YYYYMMDDHHMMSS.fffZ" (any number of fractional digits, 1 to
+//     nanosecond precision)
+//
+// The fractional component is discarded (we only return seconds).
+// Returns 0 when parsing fails so callers can treat it as "unknown".
 func parseGeneralizedTime(value string) int64 {
 	if value == "" {
 		return 0
 	}
 
-	layouts := []string{
-		"20060102150405.0Z",
-		"20060102150405Z",
-		"20060102150405.000Z",
+	// Strip the fractional portion before calling time.Parse so we
+	// accept any number of fractional digits, not just the fixed .0
+	// / .000 layouts. Format is "YYYYMMDDHHMMSS[.frac]Z" (14 fixed
+	// numeric chars, optional dot+digits, trailing Z).
+	trimmed := value
+	if len(trimmed) >= 15 && trimmed[14] == '.' {
+		zIdx := len(trimmed) - 1
+		if trimmed[zIdx] != 'Z' {
+			return 0
+		}
+		trimmed = trimmed[:14] + "Z"
 	}
 
-	for _, layout := range layouts {
-		if t, err := time.Parse(layout, value); err == nil {
-			return t.Unix()
-		}
+	if t, err := time.Parse("20060102150405Z", trimmed); err == nil {
+		return t.Unix()
 	}
 
 	return 0

--- a/utils.go
+++ b/utils.go
@@ -129,13 +129,18 @@ func parseFileTimeSeconds(value string) int64 {
 	return parseLastLogonTimestamp(value)
 }
 
+// accountExpiresNeverSigned is the "never expires" sentinel AD stores in
+// `accountExpires` (0x7FFFFFFFFFFFFFFF = math.MaxInt64). Declared as a
+// signed int64 so parseAccountExpires can compare the decoded value
+// without the uint64→int64 cast gosec G115 flags.
+const accountExpiresNeverSigned int64 = 0x7FFFFFFFFFFFFFFF
+
 // parseAccountExpires parses the Active Directory accountExpires
 // attribute. Returns:
 //
 //   - 0 when unset or "0" (interpreted as "no expiry specified")
-//   - -1 when equal to the sentinel value 9223372036854775807 or the
-//     unsigned equivalent (0x7FFFFFFFFFFFFFFF) — conventionally "never
-//     expires"
+//   - -1 when equal to the AD "never expires" sentinel
+//     (0x7FFFFFFFFFFFFFFF / 9223372036854775807)
 //   - Otherwise the Unix-seconds timestamp of expiry.
 func parseAccountExpires(value string) int64 {
 	if value == "" || value == "0" {
@@ -147,8 +152,7 @@ func parseAccountExpires(value string) int64 {
 		return 0
 	}
 
-	// Both signed-max and AD's documented "never" value map to -1.
-	if raw == int64(accountExpiresNever) || raw == 9223372036854775807 {
+	if raw == accountExpiresNeverSigned {
 		return -1
 	}
 

--- a/utils.go
+++ b/utils.go
@@ -121,6 +121,64 @@ func parseLastLogonTimestamp(value string) int64 {
 	return unixNano / 1e9 // Convert to seconds
 }
 
+// parseFileTimeSeconds parses an Active Directory FILETIME string
+// (100-nanosecond intervals since 1601-01-01 UTC) into Unix seconds.
+// Returns 0 when the value is empty, "0", or malformed. Used for
+// attributes such as pwdLastSet and lockoutTime.
+func parseFileTimeSeconds(value string) int64 {
+	return parseLastLogonTimestamp(value)
+}
+
+// parseAccountExpires parses the Active Directory accountExpires
+// attribute. Returns:
+//
+//   - 0 when unset or "0" (interpreted as "no expiry specified")
+//   - -1 when equal to the sentinel value 9223372036854775807 or the
+//     unsigned equivalent (0x7FFFFFFFFFFFFFFF) — conventionally "never
+//     expires"
+//   - Otherwise the Unix-seconds timestamp of expiry.
+func parseAccountExpires(value string) int64 {
+	if value == "" || value == "0" {
+		return 0
+	}
+
+	raw, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return 0
+	}
+
+	// Both signed-max and AD's documented "never" value map to -1.
+	if raw == int64(accountExpiresNever) || raw == 9223372036854775807 {
+		return -1
+	}
+
+	return parseLastLogonTimestamp(value)
+}
+
+// parseGeneralizedTime parses an LDAP GeneralizedTime string
+// (RFC 4517 §3.3.13) into Unix seconds. Accepts the common AD
+// variants: "YYYYMMDDHHMMSS.fZ" and "YYYYMMDDHHMMSSZ". Returns 0
+// when parsing fails so callers can treat it as "unknown".
+func parseGeneralizedTime(value string) int64 {
+	if value == "" {
+		return 0
+	}
+
+	layouts := []string{
+		"20060102150405.0Z",
+		"20060102150405Z",
+		"20060102150405.000Z",
+	}
+
+	for _, layout := range layouts {
+		if t, err := time.Parse(layout, value); err == nil {
+			return t.Unix()
+		}
+	}
+
+	return 0
+}
+
 // convertAccountExpires converts a Go time.Time to Active Directory accountExpires format.
 // Active Directory stores accountExpires as the number of 100-nanosecond intervals since January 1, 1601 UTC.
 // A nil time represents "never expires" and returns the maximum possible value.

--- a/utils_extra_test.go
+++ b/utils_extra_test.go
@@ -1,0 +1,95 @@
+package ldap
+
+import "testing"
+
+// TestParseFileTimeSeconds covers the alias used for pwdLastSet and
+// lockoutTime. Since it delegates to parseLastLogonTimestamp, this is
+// mostly a smoke test: empty/zero/garbage all yield 0, a known AD
+// FILETIME yields the expected Unix seconds.
+func TestParseFileTimeSeconds(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		input string
+		want  int64
+	}{
+		{"empty", "", 0},
+		{"zero", "0", 0},
+		{"garbage", "not-a-number", 0},
+		// 133253376000000000 is 2023-04-07 12:00:00 UTC in AD FILETIME
+		// (= 116444736000000000 + 1680864000 × 10_000_000).
+		{"known_ad_filetime", "133253376000000000", 1680864000},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := parseFileTimeSeconds(tc.input); got != tc.want {
+				t.Fatalf("parseFileTimeSeconds(%q) = %d, want %d", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestParseAccountExpires verifies the three-way interpretation:
+// 0/empty → 0; AD sentinel "never" → -1; otherwise timestamp.
+func TestParseAccountExpires(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		input string
+		want  int64
+	}{
+		{"empty", "", 0},
+		{"zero", "0", 0},
+		{"never_sentinel", "9223372036854775807", -1},
+		{"garbage", "abc", 0},
+		// Real expiry timestamp: 2030-01-01 00:00:00 UTC.
+		// FILETIME for that date is 135379296000000000 (= 116444736000000000
+		// [1601→1970 gap] + 1893456000 * 10_000_000 [unix seconds × 100 ns]).
+		{"real_expiry", "135379296000000000", 1893456000},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := parseAccountExpires(tc.input); got != tc.want {
+				t.Fatalf("parseAccountExpires(%q) = %d, want %d", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestParseGeneralizedTime covers the common AD variants.
+func TestParseGeneralizedTime(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		input string
+		want  int64
+	}{
+		{"empty", "", 0},
+		{"garbage", "2024-01-01", 0},
+		{"without_frac", "20230101120000Z", 1672574400},
+		{"with_frac_short", "20230101120000.0Z", 1672574400},
+		{"with_frac_long", "20230101120000.000Z", 1672574400},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := parseGeneralizedTime(tc.input); got != tc.want {
+				t.Fatalf("parseGeneralizedTime(%q) = %d, want %d", tc.input, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Extends the `User` struct with the identity, org, security-posture and audit timestamps commonly surfaced in admin UIs (motivated by a pile of missing fields in [netresearch/ldap-manager](https://github.com/netresearch/ldap-manager)'s new drawer/detail views).

**New fields on `User`:**

| Field | LDAP attribute | Notes |
|---|---|---|
| `GivenName` | `givenName` | First name |
| `Surname` | `sn` | Family name |
| `DisplayName` | `displayName` | May differ from `CN` |
| `Title`, `Department`, `Company` | `title`, `department`, `company` | Org context |
| `ManagerDN` | `manager` | Reports-to DN (clickable pivot) |
| `TelephoneNumber`, `Mobile` | `telephoneNumber`, `mobile` | |
| `Office` | `physicalDeliveryOfficeName` | |
| `AccountExpires` | `accountExpires` | 0 = unset, -1 = "never" (`0x7FFFFFFFFFFFFFFF`), else Unix seconds |
| `PwdLastSet`, `MustChangePassword` | `pwdLastSet` | `MustChangePassword=true` iff AD reports 0 |
| `LockoutTime` | `lockoutTime` | |
| `WhenCreated`, `WhenChanged` | `whenCreated`, `whenChanged` | Unix seconds via new `parseGeneralizedTime` |

**New helpers (in `utils.go`, covered by `utils_extra_test.go`):**

- `parseFileTimeSeconds` — thin alias around `parseLastLogonTimestamp` for any AD FILETIME (pwdLastSet, lockoutTime).
- `parseAccountExpires` — handles the AD "never" sentinel + malformed values.
- `parseGeneralizedTime` — RFC 4517 GeneralizedTime ("YYYYMMDDHHMMSS.fZ" + variants).

**Attribute list consolidation:**
The `userFields` variable (already used for one search) now covers every new attribute plus `uid` for OpenLDAP compatibility, and replaces the three inline `Attributes: []string{…}` lists previously scattered across `users.go`. Servers silently ignore attribute names they don't know, so a single shared list works for both AD and OpenLDAP.

## Test plan
- [x] `go test -count=1 -timeout 120s -short .` — all tests pass (~59s), including the new parser tests.
- [x] Backwards-compatibility: new fields default to zero values when the directory doesn't return them; no existing test needed updating.

## Follow-ups (not in this PR)
- Same treatment for `Group` (`groupType`, `managedBy`, `whenCreated`, `whenChanged`).
- Same treatment for `Computer` (`managedBy`, `whenCreated`, `whenChanged`).