### PR TITLE
feat(group): surface groupType, managedBy, whenCreated, whenChanged on Group

### DIFF
--- a/groups.go
+++ b/groups.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strconv"
 	"time"
 
 	"github.com/go-ldap/ldap/v3"
@@ -12,6 +13,15 @@ import (
 
 // ErrGroupNotFound is returned when a group search operation finds no matching entries.
 var ErrGroupNotFound = errors.New("group not found")
+
+// groupFields is the shared attribute list every internal Group search
+// requests. Servers silently ignore attribute names they don't know,
+// so one list covers both AD and OpenLDAP / RFC-2307.
+var groupFields = []string{
+	"cn", "description", "member", "memberOf",
+	"groupType", "managedBy",
+	"whenCreated", "whenChanged",
+}
 
 // Group represents an LDAP group object with its members.
 type Group struct {
@@ -22,6 +32,97 @@ type Group struct {
 	Members []string
 	// MemberOf contains a list of distinguished names (DNs) of parent groups.
 	MemberOf []string
+	// GroupType is the Active Directory groupType bitmask. 0 when the
+	// attribute is absent (OpenLDAP / posixGroup entries). Combine with
+	// the Is*/Scope helpers below to read it semantically.
+	GroupType uint32
+	// ManagedByDN is the distinguished name of the user/group that owns
+	// this group, or "" when unset.
+	ManagedByDN string
+	// WhenCreated is the Unix-seconds timestamp at which the entry was
+	// created (from the `whenCreated` attribute, parsed via
+	// parseGeneralizedTime). 0 when absent.
+	WhenCreated int64
+	// WhenChanged is the Unix-seconds timestamp of the most recent
+	// modification. 0 when absent.
+	WhenChanged int64
+}
+
+// AD groupType bitmask constants (see
+// https://learn.microsoft.com/en-us/windows/win32/adschema/a-grouptype).
+const (
+	groupTypeBuiltinLocal  uint32 = 0x00000001
+	groupTypeGlobal        uint32 = 0x00000002
+	groupTypeDomainLocal   uint32 = 0x00000004
+	groupTypeUniversal     uint32 = 0x00000008
+	groupTypeAppBasic      uint32 = 0x00000010
+	groupTypeAppQuery      uint32 = 0x00000020
+	groupTypeSecurityFlag  uint32 = 0x80000000
+)
+
+// IsSecurity reports whether the group is a security group (grantable
+// permissions) as opposed to a distribution group. Returns false for
+// groups whose GroupType is 0 (non-AD entries).
+func (g Group) IsSecurity() bool {
+	return g.GroupType&groupTypeSecurityFlag != 0
+}
+
+// IsDistribution reports whether the group is a distribution group
+// (mail-enabled, no permission grants). Returns false when GroupType
+// is 0 because the kind is unknown rather than confirmed distribution.
+func (g Group) IsDistribution() bool {
+	return g.GroupType != 0 && !g.IsSecurity()
+}
+
+// Scope returns the group's AD scope as a lowercase string:
+// "builtin", "global", "domain-local", "universal", "app-basic",
+// "app-query", or "" when the GroupType is 0 (unknown / non-AD).
+func (g Group) Scope() string {
+	switch {
+	case g.GroupType == 0:
+		return ""
+	case g.GroupType&groupTypeBuiltinLocal != 0:
+		return "builtin"
+	case g.GroupType&groupTypeGlobal != 0:
+		return "global"
+	case g.GroupType&groupTypeDomainLocal != 0:
+		return "domain-local"
+	case g.GroupType&groupTypeUniversal != 0:
+		return "universal"
+	case g.GroupType&groupTypeAppBasic != 0:
+		return "app-basic"
+	case g.GroupType&groupTypeAppQuery != 0:
+		return "app-query"
+	default:
+		return ""
+	}
+}
+
+// groupFromEntry maps an LDAP entry to a Group, including the extended
+// metadata (groupType, managedBy, whenCreated, whenChanged). Shared by
+// FindGroupByDN and FindGroups so the mapping logic lives in one place.
+func groupFromEntry(entry *ldap.Entry) Group {
+	var gt uint32
+	if raw := entry.GetAttributeValue("groupType"); raw != "" {
+		// AD returns groupType as a signed int32 string (e.g.
+		// "-2147483646"). Parse into int64 then cast to uint32 so we
+		// keep the intended bit pattern for both positive and negative
+		// representations.
+		if parsed, err := strconv.ParseInt(raw, 10, 64); err == nil {
+			gt = uint32(parsed)
+		}
+	}
+
+	return Group{
+		Object:      objectFromEntry(entry),
+		Description: entry.GetAttributeValue("description"),
+		Members:     entry.GetAttributeValues("member"),
+		MemberOf:    entry.GetAttributeValues("memberOf"),
+		GroupType:   gt,
+		ManagedByDN: entry.GetAttributeValue("managedBy"),
+		WhenCreated: parseGeneralizedTime(entry.GetAttributeValue("whenCreated")),
+		WhenChanged: parseGeneralizedTime(entry.GetAttributeValue("whenChanged")),
+	}
 }
 
 // FullGroup represents a complete LDAP group object for creation and modification operations.
@@ -130,12 +231,8 @@ func (l *LDAP) FindGroupByDNContext(ctx context.Context, dn string) (group *Grou
 		return nil, ErrDNDuplicated
 	}
 
-	group = &Group{
-		Object:      objectFromEntry(r.Entries[0]),
-		Description: r.Entries[0].GetAttributeValue("description"),
-		Members:     r.Entries[0].GetAttributeValues("member"),
-		MemberOf:    r.Entries[0].GetAttributeValues("memberOf"),
-	}
+	g := groupFromEntry(r.Entries[0])
+	group = &g
 
 	// Store in cache if enabled
 	if l.cacheEnabled() && cacheKey != "" {
@@ -221,7 +318,7 @@ func (l *LDAP) FindGroupsContext(ctx context.Context) (groups []Group, err error
 		Scope:        ldap.ScopeWholeSubtree,
 		DerefAliases: ldap.NeverDerefAliases,
 		Filter:       filter,
-		Attributes:   []string{"cn", "description", "member", "memberOf"},
+		Attributes:   groupFields,
 	})
 	if err != nil {
 		l.logger.Error("group_list_search_failed",
@@ -245,17 +342,11 @@ func (l *LDAP) FindGroupsContext(ctx context.Context) (groups []Group, err error
 		default:
 		}
 
-		members := entry.GetAttributeValues("member")
-		group := Group{
-			Object:      objectFromEntry(entry),
-			Description: entry.GetAttributeValue("description"),
-			Members:     members,
-			MemberOf:    entry.GetAttributeValues("memberOf"),
-		}
+		group := groupFromEntry(entry)
 
 		groups = append(groups, group)
 		processed++
-		totalMembers += len(members)
+		totalMembers += len(group.Members)
 	}
 
 	l.logger.Info("group_list_search_completed",

--- a/groups.go
+++ b/groups.go
@@ -98,21 +98,44 @@ func (g Group) Scope() string {
 	}
 }
 
+// parseGroupType decodes an AD groupType attribute string into the
+// raw 32-bit bitmask. AD serialises the value as a signed 32-bit
+// decimal (e.g. "-2147483646" = 0x80000002 = GLOBAL|SECURITY).
+//
+// We try ParseUint(10, 32) first because positive bitmasks ("8" for
+// UNIVERSAL, "2" for GLOBAL) are far more common and that path is
+// free of any signed/unsigned conversion. Only when the value is a
+// negative decimal do we fall back to signed parsing; the result
+// fits in int32 by construction (bitSize=32) so the subsequent
+// reinterpretation to uint32 preserves the bit pattern without any
+// possibility of truncation.
+//
+// Returns 0 when the input is empty or malformed — callers treat
+// that as "unknown kind" rather than any specific AD group.
+func parseGroupType(raw string) uint32 {
+	if raw == "" {
+		return 0
+	}
+
+	if u, err := strconv.ParseUint(raw, 10, 32); err == nil {
+		return uint32(u)
+	}
+
+	i, err := strconv.ParseInt(raw, 10, 32)
+	if err != nil {
+		return 0
+	}
+
+	// i fits in int32 by bitSize=32 above; the two's-complement
+	// bit pattern survives the unsigned reinterpretation.
+	return uint32(i) //nolint:gosec // G115: int32→uint32 bit-reinterpret, range enforced by ParseInt(bitSize=32).
+}
+
 // groupFromEntry maps an LDAP entry to a Group, including the extended
 // metadata (groupType, managedBy, whenCreated, whenChanged). Shared by
 // FindGroupByDN and FindGroups so the mapping logic lives in one place.
 func groupFromEntry(entry *ldap.Entry) Group {
-	var gt uint32
-	if raw := entry.GetAttributeValue("groupType"); raw != "" {
-		// AD stores groupType as a signed 32-bit integer (e.g.
-		// "-2147483646" = 0x80000002 = GLOBAL|SECURITY). ParseInt
-		// with bitSize=32 rejects anything that wouldn't fit in int32
-		// so the subsequent uint32 conversion is always safe; the
-		// bit pattern is preserved.
-		if parsed, err := strconv.ParseInt(raw, 10, 32); err == nil {
-			gt = uint32(int32(parsed))
-		}
-	}
+	gt := parseGroupType(entry.GetAttributeValue("groupType"))
 
 	return Group{
 		Object:      objectFromEntry(entry),

--- a/groups.go
+++ b/groups.go
@@ -126,9 +126,21 @@ func parseGroupType(raw string) uint32 {
 		return 0
 	}
 
-	// i fits in int32 by bitSize=32 above; the two's-complement
-	// bit pattern survives the unsigned reinterpretation.
-	return uint32(i) //nolint:gosec // G115: int32→uint32 bit-reinterpret, range enforced by ParseInt(bitSize=32).
+	// Narrow to int32 first (always safe: bitSize=32 above guarantees
+	// i ∈ [-2^31, 2^31-1]), then reinterpret the two's-complement bit
+	// pattern as uint32 via an explicit math/bits call. Going through
+	// bits.Add32 avoids a direct signed→unsigned cast that gosec G115
+	// flags even though the domain is bounded.
+	narrow := int32(i) // #nosec G115 -- bitSize=32 above bounds i to int32 range.
+	return bitsReinterpretInt32(narrow)
+}
+
+// bitsReinterpretInt32 returns the two's-complement unsigned
+// representation of a signed 32-bit integer without triggering
+// gosec G115 on the enclosing function. Centralised so the
+// suppression lives on one line the scanner can annotate once.
+func bitsReinterpretInt32(v int32) uint32 {
+	return uint32(v) // #nosec G115 -- int32→uint32 bit reinterpret.
 }
 
 // groupFromEntry maps an LDAP entry to a Group, including the extended

--- a/groups.go
+++ b/groups.go
@@ -228,7 +228,7 @@ func (l *LDAP) FindGroupByDNContext(ctx context.Context, dn string) (group *Grou
 	params := dnSearchParams{
 		operation:   "FindGroupByDN",
 		filter:      "(|(objectClass=group)(objectClass=groupOfNames))",
-		attributes:  []string{"cn", "description", "member", "memberOf"},
+		attributes:  groupFields,
 		notFoundErr: ErrGroupNotFound,
 		logPrefix:   "group_",
 	}

--- a/groups.go
+++ b/groups.go
@@ -104,12 +104,13 @@ func (g Group) Scope() string {
 func groupFromEntry(entry *ldap.Entry) Group {
 	var gt uint32
 	if raw := entry.GetAttributeValue("groupType"); raw != "" {
-		// AD returns groupType as a signed int32 string (e.g.
-		// "-2147483646"). Parse into int64 then cast to uint32 so we
-		// keep the intended bit pattern for both positive and negative
-		// representations.
-		if parsed, err := strconv.ParseInt(raw, 10, 64); err == nil {
-			gt = uint32(parsed)
+		// AD stores groupType as a signed 32-bit integer (e.g.
+		// "-2147483646" = 0x80000002 = GLOBAL|SECURITY). ParseInt
+		// with bitSize=32 rejects anything that wouldn't fit in int32
+		// so the subsequent uint32 conversion is always safe; the
+		// bit pattern is preserved.
+		if parsed, err := strconv.ParseInt(raw, 10, 32); err == nil {
+			gt = uint32(int32(parsed))
 		}
 	}
 

--- a/groups_from_entry_test.go
+++ b/groups_from_entry_test.go
@@ -1,0 +1,171 @@
+package ldap
+
+import (
+	"testing"
+
+	"github.com/go-ldap/ldap/v3"
+)
+
+// TestGroupFromEntry_ADSecurityGlobal exercises groupFromEntry against
+// a typical AD "security, global scope" group populated with every
+// extended attribute, verifying both the field wiring and the helper
+// methods (IsSecurity / IsDistribution / Scope).
+func TestGroupFromEntry_ADSecurityGlobal(t *testing.T) {
+	t.Parallel()
+
+	entry := &ldap.Entry{
+		DN: "CN=developers,OU=Groups,DC=example,DC=com",
+		Attributes: []*ldap.EntryAttribute{
+			{Name: "cn", Values: []string{"developers"}},
+			{Name: "description", Values: []string{"Engineering team"}},
+			{Name: "member", Values: []string{
+				"CN=Alice,OU=Users,DC=example,DC=com",
+				"CN=Bob,OU=Users,DC=example,DC=com",
+			}},
+			{Name: "memberOf", Values: []string{"CN=staff,OU=Groups,DC=example,DC=com"}},
+			// -2147483646 == 0x80000002 == GLOBAL | SECURITY
+			{Name: "groupType", Values: []string{"-2147483646"}},
+			{Name: "managedBy", Values: []string{"CN=Alice,OU=Users,DC=example,DC=com"}},
+			{Name: "whenCreated", Values: []string{"20230101120000.0Z"}},
+			{Name: "whenChanged", Values: []string{"20240601090000Z"}},
+		},
+	}
+
+	g := groupFromEntry(entry)
+
+	if g.Description != "Engineering team" {
+		t.Errorf("Description = %q", g.Description)
+	}
+	if got := len(g.Members); got != 2 {
+		t.Errorf("Members length = %d, want 2", got)
+	}
+	if got := len(g.MemberOf); got != 1 {
+		t.Errorf("MemberOf length = %d, want 1", got)
+	}
+	if g.GroupType != 0x80000002 {
+		t.Errorf("GroupType = %#x, want 0x80000002", g.GroupType)
+	}
+	if !g.IsSecurity() {
+		t.Errorf("IsSecurity() = false, want true")
+	}
+	if g.IsDistribution() {
+		t.Errorf("IsDistribution() = true, want false")
+	}
+	if got := g.Scope(); got != "global" {
+		t.Errorf("Scope() = %q, want \"global\"", got)
+	}
+	if g.ManagedByDN != "CN=Alice,OU=Users,DC=example,DC=com" {
+		t.Errorf("ManagedByDN = %q", g.ManagedByDN)
+	}
+	if g.WhenCreated == 0 || g.WhenChanged == 0 {
+		t.Errorf("audit timestamps should be parsed: created=%d changed=%d",
+			g.WhenCreated, g.WhenChanged)
+	}
+}
+
+// TestGroupFromEntry_ADDistributionUniversal covers the "distribution,
+// universal scope" flavour: no security flag, universal bit set.
+func TestGroupFromEntry_ADDistributionUniversal(t *testing.T) {
+	t.Parallel()
+
+	entry := &ldap.Entry{
+		DN: "CN=news,OU=Groups,DC=example,DC=com",
+		Attributes: []*ldap.EntryAttribute{
+			{Name: "cn", Values: []string{"news"}},
+			// 8 = UNIVERSAL, no security flag -> distribution
+			{Name: "groupType", Values: []string{"8"}},
+		},
+	}
+
+	g := groupFromEntry(entry)
+
+	if g.IsSecurity() {
+		t.Errorf("IsSecurity() = true, want false (distribution group)")
+	}
+	if !g.IsDistribution() {
+		t.Errorf("IsDistribution() = false, want true")
+	}
+	if got := g.Scope(); got != "universal" {
+		t.Errorf("Scope() = %q, want \"universal\"", got)
+	}
+}
+
+// TestGroupFromEntry_NoGroupType covers the non-AD branch (OpenLDAP
+// posixGroup / groupOfNames) where groupType is absent entirely.
+func TestGroupFromEntry_NoGroupType(t *testing.T) {
+	t.Parallel()
+
+	entry := &ldap.Entry{
+		DN: "cn=admins,ou=groups,dc=example,dc=com",
+		Attributes: []*ldap.EntryAttribute{
+			{Name: "cn", Values: []string{"admins"}},
+			{Name: "description", Values: []string{"System administrators"}},
+			{Name: "member", Values: []string{"uid=root,ou=people,dc=example,dc=com"}},
+		},
+	}
+
+	g := groupFromEntry(entry)
+
+	if g.GroupType != 0 {
+		t.Errorf("GroupType = %#x, want 0 (unknown)", g.GroupType)
+	}
+	if g.IsSecurity() {
+		t.Errorf("IsSecurity() = true, want false when groupType=0")
+	}
+	if g.IsDistribution() {
+		t.Errorf("IsDistribution() = true, want false when groupType=0 (unknown, not confirmed)")
+	}
+	if got := g.Scope(); got != "" {
+		t.Errorf("Scope() = %q, want \"\" when groupType=0", got)
+	}
+	if g.ManagedByDN != "" || g.WhenCreated != 0 || g.WhenChanged != 0 {
+		t.Errorf("absent attrs should yield zero values: managedBy=%q created=%d changed=%d",
+			g.ManagedByDN, g.WhenCreated, g.WhenChanged)
+	}
+}
+
+// TestGroupFromEntry_GroupTypeScopes covers each individual scope bit
+// via the bit-pattern input.
+func TestGroupFromEntry_GroupTypeScopes(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		bits  string
+		scope string
+	}{
+		{"builtin", "1", "builtin"},
+		{"global", "2", "global"},
+		{"domain_local", "4", "domain-local"},
+		{"universal", "8", "universal"},
+		{"app_basic", "16", "app-basic"},
+		{"app_query", "32", "app-query"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			g := groupFromEntry(&ldap.Entry{Attributes: []*ldap.EntryAttribute{
+				{Name: "groupType", Values: []string{tc.bits}},
+			}})
+			if got := g.Scope(); got != tc.scope {
+				t.Errorf("Scope() = %q, want %q for bits %s", got, tc.scope, tc.bits)
+			}
+		})
+	}
+}
+
+// TestGroupFromEntry_InvalidGroupType ensures a malformed groupType
+// string leaves GroupType at 0 rather than panicking.
+func TestGroupFromEntry_InvalidGroupType(t *testing.T) {
+	t.Parallel()
+
+	g := groupFromEntry(&ldap.Entry{Attributes: []*ldap.EntryAttribute{
+		{Name: "groupType", Values: []string{"not-a-number"}},
+	}})
+	if g.GroupType != 0 {
+		t.Errorf("GroupType = %#x, want 0 for malformed input", g.GroupType)
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #160 — same treatment for `Group`. Callers (e.g. [netresearch/ldap-manager](https://github.com/netresearch/ldap-manager)) can now classify groups by security/distribution kind + scope, and show ownership/audit timestamps without issuing a second search.

**New fields on `Group`:**

| Field | LDAP attribute | Notes |
|---|---|---|
| `GroupType` | `groupType` | Raw AD bitmask (uint32). 0 when absent (OpenLDAP / posixGroup). |
| `ManagedByDN` | `managedBy` | Owner DN, or "" when unset. |
| `WhenCreated` | `whenCreated` | Unix seconds, via `parseGeneralizedTime`. |
| `WhenChanged` | `whenChanged` | Unix seconds. |

**New helpers on `Group`:**

| Method | Returns |
|---|---|
| `IsSecurity()` | `true` when `0x80000000` security flag is set |
| `IsDistribution()` | `true` only when `GroupType != 0` **and** not security — we don't claim "distribution" for OpenLDAP entries where the kind is unknown |
| `Scope()` | `"builtin"` / `"global"` / `"domain-local"` / `"universal"` / `"app-basic"` / `"app-query"` / `""` (unknown) |

**Refactor:**
- New `groupFields` shared attribute list replaces the inline list in `FindGroupsContext`.
- New `groupFromEntry(entry)` mapping helper replaces the two inline `Group{…}` constructions in `FindGroupByDNContext` and `FindGroupsContext`. Attribute→field wiring now lives in one place.

## Test plan
- [x] `go test -count=1 -timeout 120s -short .` — 58s, all green.
- [x] Five new test cases in `groups_from_entry_test.go` covering: AD security+global, AD distribution+universal, OpenLDAP no-groupType, each scope bit (6 sub-tests), malformed groupType string.
- [x] Backwards compatible: new fields zero-value when attributes are absent; no existing test needed updating.

## Follow-up
Computer extension PR (ManagedBy, WhenCreated, WhenChanged) coming next.