### PR TITLE
feat(computer): surface managedBy, whenCreated, whenChanged on Computer

### DIFF
--- a/computers.go
+++ b/computers.go
@@ -13,6 +13,16 @@ import (
 // ErrComputerNotFound is returned when a computer search operation finds no matching entries.
 var ErrComputerNotFound = errors.New("computer not found")
 
+// computerFields is the shared attribute list every internal Computer
+// search requests. Servers silently ignore attribute names they don't
+// know, so a single list works for both AD and OpenLDAP / RFC-4524.
+var computerFields = []string{
+	"memberOf", "cn", "sAMAccountName", "userAccountControl",
+	"operatingSystem", "operatingSystemVersion", "operatingSystemServicePack",
+	"description", "dNSHostName", "lastLogonTimestamp",
+	"managedBy", "whenCreated", "whenChanged",
+}
+
 // Computer represents an LDAP computer object with common attributes.
 type Computer struct {
 	Object
@@ -32,8 +42,62 @@ type Computer struct {
 	ServicePack string
 	// LastLogon contains the timestamp of the last logon (from lastLogonTimestamp, replicated).
 	LastLogon int64
+	// ManagedByDN is the distinguished name of the user/group that owns
+	// this computer (from `managedBy`), or "" when unset.
+	ManagedByDN string
+	// WhenCreated is the Unix-seconds timestamp at which the entry was
+	// created (from `whenCreated`, parsed via parseGeneralizedTime).
+	// 0 when the attribute is absent (OpenLDAP / RFC-4524 entries).
+	WhenCreated int64
+	// WhenChanged is the Unix-seconds timestamp of the most recent
+	// modification. 0 when absent.
+	WhenChanged int64
 	// Groups contains a list of distinguished names (DNs) of groups the computer belongs to.
 	Groups []string
+}
+
+// computerFromEntry maps an LDAP entry to a Computer, handling the
+// AD vs OpenLDAP enablement+account-name split. Returns a non-nil
+// error only when AD's userAccountControl is present but malformed;
+// OpenLDAP entries never produce an error. Callers can choose to
+// propagate the error (FindComputerByDN) or skip the entry
+// (FindComputers).
+func computerFromEntry(entry *ldap.Entry) (Computer, error) {
+	var (
+		enabled        bool
+		samAccountName string
+	)
+
+	if uac := entry.GetAttributeValue("userAccountControl"); uac != "" {
+		var err error
+		enabled, err = parseObjectEnabled(uac)
+		if err != nil {
+			return Computer{}, err
+		}
+
+		samAccountName = entry.GetAttributeValue("sAMAccountName")
+	} else {
+		// OpenLDAP / RFC-4524 device entries: no userAccountControl —
+		// default to enabled and use cn as the account name.
+		enabled = true
+		samAccountName = entry.GetAttributeValue("cn")
+	}
+
+	return Computer{
+		Object:         objectFromEntry(entry),
+		SAMAccountName: samAccountName,
+		Enabled:        enabled,
+		Description:    entry.GetAttributeValue("description"),
+		DNSHostName:    entry.GetAttributeValue("dNSHostName"),
+		OS:             entry.GetAttributeValue("operatingSystem"),
+		OSVersion:      entry.GetAttributeValue("operatingSystemVersion"),
+		ServicePack:    entry.GetAttributeValue("operatingSystemServicePack"),
+		LastLogon:      parseLastLogonTimestamp(entry.GetAttributeValue("lastLogonTimestamp")),
+		ManagedByDN:    entry.GetAttributeValue("managedBy"),
+		WhenCreated:    parseGeneralizedTime(entry.GetAttributeValue("whenCreated")),
+		WhenChanged:    parseGeneralizedTime(entry.GetAttributeValue("whenChanged")),
+		Groups:         entry.GetAttributeValues("memberOf"),
+	}, nil
 }
 
 // FullComputer represents a complete LDAP computer object for creation and modification operations.
@@ -124,7 +188,7 @@ func (l *LDAP) FindComputerByDNContext(ctx context.Context, dn string) (computer
 		Scope:        ldap.ScopeBaseObject,
 		DerefAliases: ldap.NeverDerefAliases,
 		Filter:       filter,
-		Attributes:   []string{"memberOf", "cn", "sAMAccountName", "userAccountControl", "operatingSystem", "operatingSystemVersion", "operatingSystemServicePack", "description", "dNSHostName", "lastLogonTimestamp"},
+		Attributes:   computerFields,
 	})
 	if err != nil {
 		// If LDAP error indicates object not found, return ErrComputerNotFound
@@ -160,43 +224,16 @@ func (l *LDAP) FindComputerByDNContext(ctx context.Context, dn string) (computer
 		return nil, ErrDNDuplicated
 	}
 
-	var enabled bool
-	var samAccountName string
-
-	// Handle Active Directory vs OpenLDAP compatibility
-	if uac := r.Entries[0].GetAttributeValue("userAccountControl"); uac != "" {
-		// Active Directory
-		var err error
-		enabled, err = parseObjectEnabled(uac)
-		if err != nil {
-			l.logger.Error("computer_uac_parsing_failed",
-				slog.String("dn", dn),
-				slog.String("uac", uac),
-				slog.String("error", err.Error()))
-			return nil, err
-		}
-		samAccountName = r.Entries[0].GetAttributeValue("sAMAccountName")
-	} else {
-		// OpenLDAP - devices are typically enabled, use cn as account name
-		enabled = true
-		samAccountName = r.Entries[0].GetAttributeValue("cn")
-		l.logger.Debug("computer_using_openldap_compatibility",
+	cm, err := computerFromEntry(r.Entries[0])
+	if err != nil {
+		l.logger.Error("computer_uac_parsing_failed",
 			slog.String("dn", dn),
-			slog.String("account_name", samAccountName))
+			slog.String("error", err.Error()))
+
+		return nil, err
 	}
 
-	computer = &Computer{
-		Object:         objectFromEntry(r.Entries[0]),
-		SAMAccountName: samAccountName,
-		Enabled:        enabled,
-		Description:    r.Entries[0].GetAttributeValue("description"),
-		DNSHostName:    r.Entries[0].GetAttributeValue("dNSHostName"),
-		OS:             r.Entries[0].GetAttributeValue("operatingSystem"),
-		OSVersion:      r.Entries[0].GetAttributeValue("operatingSystemVersion"),
-		ServicePack:    r.Entries[0].GetAttributeValue("operatingSystemServicePack"),
-		LastLogon:      parseLastLogonTimestamp(r.Entries[0].GetAttributeValue("lastLogonTimestamp")),
-		Groups:         r.Entries[0].GetAttributeValues("memberOf"),
-	}
+	computer = &cm
 
 	l.logger.Debug("computer_found_by_dn",
 		slog.String("operation", "FindComputerByDN"),
@@ -283,7 +320,7 @@ func (l *LDAP) FindComputerBySAMAccountNameContext(ctx context.Context, sAMAccou
 		Scope:        ldap.ScopeWholeSubtree,
 		DerefAliases: ldap.NeverDerefAliases,
 		Filter:       filter,
-		Attributes:   []string{"memberOf", "cn", "sAMAccountName", "userAccountControl", "operatingSystem", "operatingSystemVersion", "operatingSystemServicePack", "description", "dNSHostName", "lastLogonTimestamp"},
+		Attributes:   computerFields,
 	})
 	if err != nil {
 		l.logger.Error("computer_search_by_sam_account_failed",
@@ -311,43 +348,16 @@ func (l *LDAP) FindComputerBySAMAccountNameContext(ctx context.Context, sAMAccou
 		return nil, ErrSAMAccountNameDuplicated
 	}
 
-	var enabled bool
-	var samAccountName string
-
-	// Handle Active Directory vs OpenLDAP compatibility
-	if uac := r.Entries[0].GetAttributeValue("userAccountControl"); uac != "" {
-		// Active Directory
-		var err error
-		enabled, err = parseObjectEnabled(uac)
-		if err != nil {
-			l.logger.Error("computer_uac_parsing_failed",
-				slog.String("sam_account_name", sAMAccountName),
-				slog.String("uac", uac),
-				slog.String("error", err.Error()))
-			return nil, err
-		}
-		samAccountName = r.Entries[0].GetAttributeValue("sAMAccountName")
-	} else {
-		// OpenLDAP - devices are typically enabled, use cn as account name
-		enabled = true
-		samAccountName = r.Entries[0].GetAttributeValue("cn")
-		l.logger.Debug("computer_using_openldap_compatibility",
+	cm, err := computerFromEntry(r.Entries[0])
+	if err != nil {
+		l.logger.Error("computer_uac_parsing_failed",
 			slog.String("sam_account_name", sAMAccountName),
-			slog.String("account_name", samAccountName))
+			slog.String("error", err.Error()))
+
+		return nil, err
 	}
 
-	computer = &Computer{
-		Object:         objectFromEntry(r.Entries[0]),
-		SAMAccountName: samAccountName,
-		Enabled:        enabled,
-		Description:    r.Entries[0].GetAttributeValue("description"),
-		DNSHostName:    r.Entries[0].GetAttributeValue("dNSHostName"),
-		OS:             r.Entries[0].GetAttributeValue("operatingSystem"),
-		OSVersion:      r.Entries[0].GetAttributeValue("operatingSystemVersion"),
-		ServicePack:    r.Entries[0].GetAttributeValue("operatingSystemServicePack"),
-		LastLogon:      parseLastLogonTimestamp(r.Entries[0].GetAttributeValue("lastLogonTimestamp")),
-		Groups:         r.Entries[0].GetAttributeValues("memberOf"),
-	}
+	computer = &cm
 
 	l.logger.Debug("computer_found_by_sam_account",
 		slog.String("operation", "FindComputerBySAMAccountName"),
@@ -424,7 +434,7 @@ func (l *LDAP) FindComputersContext(ctx context.Context) (computers []Computer, 
 		Scope:        ldap.ScopeWholeSubtree,
 		DerefAliases: ldap.NeverDerefAliases,
 		Filter:       filter,
-		Attributes:   []string{"cn", "memberOf", "sAMAccountName", "userAccountControl", "operatingSystem", "operatingSystemVersion", "operatingSystemServicePack", "description", "dNSHostName", "lastLogonTimestamp"},
+		Attributes:   computerFields,
 	})
 	if err != nil {
 		l.logger.Error("computer_list_search_failed",
@@ -448,39 +458,15 @@ func (l *LDAP) FindComputersContext(ctx context.Context) (computers []Computer, 
 		default:
 		}
 
-		// Handle Active Directory vs OpenLDAP compatibility for parsing
-		var enabled bool
-		var samAccountName string
-		if uac := entry.GetAttributeValue("userAccountControl"); uac != "" {
-			// Active Directory
-			var err error
-			enabled, err = parseObjectEnabled(uac)
-			if err != nil {
-				l.logger.Debug("computer_entry_skipped_uac_parsing",
-					slog.String("dn", entry.DN),
-					slog.String("uac", uac),
-					slog.String("error", err.Error()))
-				skipped++
-				continue
-			}
-			samAccountName = entry.GetAttributeValue("sAMAccountName")
-		} else {
-			// OpenLDAP - devices are typically enabled, use cn as account name
-			enabled = true
-			samAccountName = entry.GetAttributeValue("cn")
-		}
+		computer, cerr := computerFromEntry(entry)
+		if cerr != nil {
+			l.logger.Debug("computer_entry_skipped_uac_parsing",
+				slog.String("dn", entry.DN),
+				slog.String("error", cerr.Error()))
 
-		computer := Computer{
-			Object:         objectFromEntry(entry),
-			SAMAccountName: samAccountName,
-			Enabled:        enabled,
-			Description:    entry.GetAttributeValue("description"),
-			DNSHostName:    entry.GetAttributeValue("dNSHostName"),
-			OS:             entry.GetAttributeValue("operatingSystem"),
-			OSVersion:      entry.GetAttributeValue("operatingSystemVersion"),
-			ServicePack:    entry.GetAttributeValue("operatingSystemServicePack"),
-			LastLogon:      parseLastLogonTimestamp(entry.GetAttributeValue("lastLogonTimestamp")),
-			Groups:         entry.GetAttributeValues("memberOf"),
+			skipped++
+
+			continue
 		}
 
 		computers = append(computers, computer)

--- a/computers.go
+++ b/computers.go
@@ -13,9 +13,10 @@ import (
 // ErrComputerNotFound is returned when a computer search operation finds no matching entries.
 var ErrComputerNotFound = errors.New("computer not found")
 
-// computerFields is the shared attribute list every internal Computer
-// search requests. Servers silently ignore attribute names they don't
-// know, so a single list works for both AD and OpenLDAP / RFC-4524.
+// computerFields is the shared attribute list for every internal
+// Computer search request. Servers silently ignore attribute names
+// they don't know, so a single list works for both AD and
+// OpenLDAP / RFC-4524 device entries.
 var computerFields = []string{
 	"memberOf", "cn", "sAMAccountName", "userAccountControl",
 	"operatingSystem", "operatingSystemVersion", "operatingSystemServicePack",
@@ -228,6 +229,7 @@ func (l *LDAP) FindComputerByDNContext(ctx context.Context, dn string) (computer
 	if err != nil {
 		l.logger.Error("computer_uac_parsing_failed",
 			slog.String("dn", dn),
+			slog.String("uac", r.Entries[0].GetAttributeValue("userAccountControl")),
 			slog.String("error", err.Error()))
 
 		return nil, err
@@ -352,6 +354,7 @@ func (l *LDAP) FindComputerBySAMAccountNameContext(ctx context.Context, sAMAccou
 	if err != nil {
 		l.logger.Error("computer_uac_parsing_failed",
 			slog.String("sam_account_name", sAMAccountName),
+			slog.String("uac", r.Entries[0].GetAttributeValue("userAccountControl")),
 			slog.String("error", err.Error()))
 
 		return nil, err
@@ -462,6 +465,7 @@ func (l *LDAP) FindComputersContext(ctx context.Context) (computers []Computer, 
 		if cerr != nil {
 			l.logger.Debug("computer_entry_skipped_uac_parsing",
 				slog.String("dn", entry.DN),
+				slog.String("uac", entry.GetAttributeValue("userAccountControl")),
 				slog.String("error", cerr.Error()))
 
 			skipped++

--- a/computers_from_entry_test.go
+++ b/computers_from_entry_test.go
@@ -1,0 +1,124 @@
+package ldap
+
+import (
+	"testing"
+
+	"github.com/go-ldap/ldap/v3"
+)
+
+// TestComputerFromEntry_ADFull exercises computerFromEntry against a
+// typical AD entry populated with every extended attribute.
+func TestComputerFromEntry_ADFull(t *testing.T) {
+	t.Parallel()
+
+	entry := &ldap.Entry{
+		DN: "CN=WS01,OU=Computers,DC=example,DC=com",
+		Attributes: []*ldap.EntryAttribute{
+			{Name: "cn", Values: []string{"WS01"}},
+			{Name: "sAMAccountName", Values: []string{"WS01$"}},
+			{Name: "userAccountControl", Values: []string{"4096"}}, // workstation trust, enabled
+			{Name: "description", Values: []string{"Engineering workstation"}},
+			{Name: "dNSHostName", Values: []string{"ws01.example.com"}},
+			{Name: "operatingSystem", Values: []string{"Windows 11 Pro"}},
+			{Name: "operatingSystemVersion", Values: []string{"10.0.22621"}},
+			{Name: "operatingSystemServicePack", Values: []string{""}},
+			{Name: "lastLogonTimestamp", Values: []string{"133253376000000000"}},
+			{Name: "managedBy", Values: []string{"CN=Alice,OU=Users,DC=example,DC=com"}},
+			{Name: "whenCreated", Values: []string{"20230101120000.0Z"}},
+			{Name: "whenChanged", Values: []string{"20240601090000Z"}},
+			{Name: "memberOf", Values: []string{"CN=workstations,OU=Groups,DC=example,DC=com"}},
+		},
+	}
+
+	cp, err := computerFromEntry(entry)
+	if err != nil {
+		t.Fatalf("computerFromEntry returned error: %v", err)
+	}
+
+	if !cp.Enabled {
+		t.Errorf("Enabled = false, want true (uac=4096)")
+	}
+	if cp.SAMAccountName != "WS01$" {
+		t.Errorf("SAMAccountName = %q, want WS01$", cp.SAMAccountName)
+	}
+	if cp.Description != "Engineering workstation" {
+		t.Errorf("Description = %q", cp.Description)
+	}
+	if cp.DNSHostName != "ws01.example.com" {
+		t.Errorf("DNSHostName = %q", cp.DNSHostName)
+	}
+	if cp.OS != "Windows 11 Pro" || cp.OSVersion != "10.0.22621" {
+		t.Errorf("OS fields mismatched: os=%q version=%q", cp.OS, cp.OSVersion)
+	}
+	if cp.LastLogon != 1680864000 {
+		t.Errorf("LastLogon = %d, want 1680864000", cp.LastLogon)
+	}
+	if cp.ManagedByDN != "CN=Alice,OU=Users,DC=example,DC=com" {
+		t.Errorf("ManagedByDN = %q", cp.ManagedByDN)
+	}
+	if cp.WhenCreated == 0 || cp.WhenChanged == 0 {
+		t.Errorf("audit timestamps should be parsed: created=%d changed=%d",
+			cp.WhenCreated, cp.WhenChanged)
+	}
+	if got := len(cp.Groups); got != 1 {
+		t.Errorf("Groups length = %d, want 1", got)
+	}
+}
+
+// TestComputerFromEntry_OpenLDAPDevice covers the OpenLDAP branch
+// (no userAccountControl; cn used as the account name; Enabled
+// defaults to true; audit timestamps absent).
+func TestComputerFromEntry_OpenLDAPDevice(t *testing.T) {
+	t.Parallel()
+
+	entry := &ldap.Entry{
+		DN: "cn=laptop-001,ou=devices,dc=example,dc=com",
+		Attributes: []*ldap.EntryAttribute{
+			{Name: "cn", Values: []string{"laptop-001"}},
+			{Name: "description", Values: []string{"Bob's laptop"}},
+		},
+	}
+
+	cp, err := computerFromEntry(entry)
+	if err != nil {
+		t.Fatalf("computerFromEntry returned error: %v", err)
+	}
+
+	if !cp.Enabled {
+		t.Errorf("OpenLDAP device should default Enabled=true")
+	}
+	if cp.SAMAccountName != "laptop-001" {
+		t.Errorf("SAMAccountName = %q, want laptop-001 (cn fallback)", cp.SAMAccountName)
+	}
+	if cp.Description != "Bob's laptop" {
+		t.Errorf("Description = %q", cp.Description)
+	}
+	if cp.OS != "" || cp.OSVersion != "" || cp.DNSHostName != "" {
+		t.Errorf("AD-only fields should be empty for this entry")
+	}
+	if cp.WhenCreated != 0 || cp.WhenChanged != 0 || cp.ManagedByDN != "" {
+		t.Errorf("audit fields should be zero-valued when absent: created=%d changed=%d managed=%q",
+			cp.WhenCreated, cp.WhenChanged, cp.ManagedByDN)
+	}
+}
+
+// TestComputerFromEntry_BadUAC ensures malformed userAccountControl
+// propagates as an error so FindComputerByDN can return it and
+// FindComputers can skip the entry.
+func TestComputerFromEntry_BadUAC(t *testing.T) {
+	t.Parallel()
+
+	entry := &ldap.Entry{
+		DN: "CN=WS02,OU=Computers,DC=example,DC=com",
+		Attributes: []*ldap.EntryAttribute{
+			{Name: "cn", Values: []string{"WS02"}},
+			{Name: "userAccountControl", Values: []string{"not-a-number"}},
+			{Name: "sAMAccountName", Values: []string{"WS02$"}},
+		},
+	}
+
+	_, err := computerFromEntry(entry)
+	if err == nil {
+		t.Fatalf("computerFromEntry returned nil error for malformed UAC")
+	}
+}


### PR DESCRIPTION
## Summary

Final piece in the extend-entity-attributes trio (#160 User, #161 Group). Adds ownership + audit timestamps to `Computer` and centralises the attribute list + mapping helper.

**New fields on `Computer`:**

| Field | LDAP attribute | Notes |
|---|---|---|
| `ManagedByDN` | `managedBy` | Owner DN, or "" when unset. |
| `WhenCreated` | `whenCreated` | Unix seconds, via `parseGeneralizedTime` (added in #160). |
| `WhenChanged` | `whenChanged` | Unix seconds. |

**Refactor:**
- New `computerFields` shared attribute list replaces three inline lists in `FindComputerByDN`, `FindComputerBySAMAccountName`, and `FindComputers`.
- New `computerFromEntry(entry) (Computer, error)` mapping helper replaces the three inline `Computer{…}` constructions. Keeps the AD vs OpenLDAP enablement / account-name split in one place. Returns a non-nil error only when AD's `userAccountControl` is present but malformed — callers decide whether to propagate (find-one) or skip (find-many).

## Test plan
- [x] `go test -count=1 -timeout 120s -short .` — 58s, all green.
- [x] Three new test cases in `computers_from_entry_test.go` covering: AD entry with every extended attribute populated, OpenLDAP device (no UAC → cn fallback, AD-only fields empty), malformed UAC returns error.
- [x] Backwards compatible: new fields default to zero values when attributes are absent.

Depends on: #161 (Group) — should land after that one.