### PR TITLE
ci(drift): record release.yml cosign-sign override as intentional-drift

### DIFF
--- a/.github/template.yaml
+++ b/.github/template.yaml
@@ -8,3 +8,9 @@ intentional-drift:
     \ testcontainer). E2E deliberately not enabled \u2014 this is a library (no executable\
     \ surface); the integration tier already exercises end-to-end behaviour against\
     \ a real OpenLDAP server"
+- path: .github/workflows/release.yml
+  reason: "cosign 3.x path bug in the reusable release workflow (create bundle file:\
+    \ open : no such file or directory). 'cosign-sign: false' disables keyless signing\
+    \ locally; GitHub artifact attestation (attest: true default) still provides provenance.\
+    \ id-token + attestations permissions added for that attestation. Remove when the\
+    \ reusable release workflow upstream fixes the cosign path issue."


### PR DESCRIPTION
Commits [22af566](https://github.com/netresearch/simple-ldap-go/commit/22af566) and [a5b75d0](https://github.com/netresearch/simple-ldap-go/commit/a5b75d0) added the cosign 3.x workaround to `.github/workflows/release.yml` but didn't update `template.yaml` to record the divergence. That's now failing the Template Drift check on main.

## Change

Add the `.github/workflows/release.yml` path to `intentional-drift:` with the reason spelled out (cosign 3.x path bug workaround) and the removal trigger (upstream reusable release workflow fix).

## Test plan

- [x] Drift check on this PR passes (previously failing on main)
- After merge, main's drift job should go green again