### PR TITLE
ci(drift): reword cosign-sign disablement scope per #163 review

### DIFF
--- a/.github/template.yaml
+++ b/.github/template.yaml
@@ -11,6 +11,7 @@ intentional-drift:
 - path: .github/workflows/release.yml
   reason: "cosign 3.x path bug in the reusable release workflow (create bundle file:\
     \ open : no such file or directory). 'cosign-sign: false' disables keyless signing\
-    \ locally; GitHub artifact attestation (attest: true default) still provides provenance.\
-    \ id-token + attestations permissions added for that attestation. Remove when the\
-    \ reusable release workflow upstream fixes the cosign path issue."
+    \ in this repo's release workflow; GitHub artifact attestation (attest: true default)\
+    \ still provides provenance. id-token + attestations permissions added for that\
+    \ attestation. Remove when the reusable release workflow upstream fixes the cosign\
+    \ path issue."


### PR DESCRIPTION
Copilot flagged that 'disables keyless signing locally' in the drift reason is ambiguous — reads as 'on developer's machine' rather than 'in this repo's release workflow'. Swapped to the more specific wording.

## Thread resolved after merge

PRRT_kwDOJ1EFws58piF8