### PR TITLE
test(uac): cover error-mapping, bit-arithmetic, release-log paths

### DIFF
--- a/disable.go
+++ b/disable.go
@@ -36,6 +36,7 @@ package ldap
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strconv"
@@ -110,17 +111,20 @@ func (l *LDAP) EnableComputerContext(ctx context.Context, dn string) error {
 // surface ErrUserNotFound and computers surface ErrComputerNotFound).
 //
 // Connection and permission errors are wrapped via WrapLDAPError.
+//
+// Implementation note: the read-modify steps are split into two pure
+// helpers (classifyUACSearchResult and applyUACBitToEntry) so the
+// error-mapping and bit-arithmetic branches are exercisable from
+// unit tests without an LDAP server. updateUACBit itself only
+// orchestrates conn → search → classify → apply → modify and is
+// covered by the offline-server connection-error test in disable_test.go.
 func (l *LDAP) updateUACBit(ctx context.Context, dn string, bit uint32, set bool, notFoundErr error) error {
 	conn, err := l.GetConnectionContext(ctx)
 	if err != nil {
 		return connectionError("modify", "uac", err)
 	}
 	defer func() {
-		if releaseErr := l.ReleaseConnection(conn); releaseErr != nil {
-			l.logger.Debug("connection_close_error",
-				slog.String("operation", "updateUACBit"),
-				slog.String("error", releaseErr.Error()))
-		}
+		l.logConnectionReleaseError("updateUACBit", l.ReleaseConnection(conn))
 	}()
 
 	searchReq := ldap.NewSearchRequest(
@@ -136,44 +140,17 @@ func (l *LDAP) updateUACBit(ctx context.Context, dn string, bit uint32, set bool
 	// Single base-object lookup — Search rather than SearchWithPaging
 	// because there is at most one entry by definition (ScopeBaseObject
 	// + SizeLimit=1) and paging adds an unnecessary control round-trip.
-	sr, err := conn.Search(searchReq)
-	if err != nil {
-		// AD typically reports a missing DN as LDAPResultNoSuchObject
-		// on the search itself rather than an empty result set. Map
-		// that to the caller-supplied sentinel so the error shape
-		// matches the rest of the API (FindUserByDN, FindComputerByDN).
-		if ldapErr, ok := err.(*ldap.Error); ok && ldapErr.ResultCode == ldap.LDAPResultNoSuchObject {
-			return fmt.Errorf("%w: %s", notFoundErr, dn)
-		}
-		return WrapLDAPError("SearchUAC", l.config.Server, err)
+	sr, searchErr := conn.Search(searchReq)
+	entry, mapErr := classifyUACSearchResult(sr, searchErr, dn, notFoundErr, l.config.Server)
+	if mapErr != nil {
+		return mapErr
 	}
 
-	if len(sr.Entries) == 0 {
-		return fmt.Errorf("%w: %s", notFoundErr, dn)
+	_, next, changed, applyErr := applyUACBitToEntry(entry, bit, set)
+	if applyErr != nil {
+		return applyErr
 	}
-
-	raw := sr.Entries[0].GetAttributeValue("userAccountControl")
-	if raw == "" {
-		// No userAccountControl on the entry — only AD has this
-		// attribute. Return a clear error so OpenLDAP callers get a
-		// useful message instead of a silent no-op.
-		return fmt.Errorf("userAccountControl attribute missing on %s (not an Active Directory entry?)", dn)
-	}
-
-	current64, err := strconv.ParseUint(raw, 10, 32)
-	if err != nil {
-		return fmt.Errorf("parse userAccountControl %q on %s: %w", raw, dn, err)
-	}
-
-	current := uint32(current64)
-	var next uint32
-	if set {
-		next = current | bit
-	} else {
-		next = current &^ bit
-	}
-
-	if next == current {
+	if !changed {
 		// Already in the desired state — nothing to do. Writing the
 		// same value is harmless but we skip the round-trip.
 		return nil
@@ -182,4 +159,83 @@ func (l *LDAP) updateUACBit(ctx context.Context, dn string, bit uint32, set bool
 	return l.ModifyUserContext(ctx, dn, map[string][]string{
 		"userAccountControl": {strconv.FormatUint(uint64(next), 10)},
 	})
+}
+
+// logConnectionReleaseError emits a debug log line when releasing a
+// connection back to the pool fails. Extracted so the (rare but
+// non-trivial) defer path can be unit-tested without an LDAP server.
+// A nil err is the success path and is silent.
+func (l *LDAP) logConnectionReleaseError(operation string, err error) {
+	if err == nil {
+		return
+	}
+	l.logger.Debug("connection_close_error",
+		slog.String("operation", operation),
+		slog.String("error", err.Error()))
+}
+
+// classifyUACSearchResult maps a base-object search result + error
+// into either the single matching entry or a typed error. Pure
+// function used by updateUACBit so the LDAPResultNoSuchObject /
+// empty-result-set / wrap branches are unit-testable.
+//
+// Returns:
+//   - the matching entry on success (sr.Entries[0])
+//   - notFoundErr (wrapped with dn) when the search reported
+//     LDAPResultNoSuchObject *or* when the result set is empty
+//   - a WrapLDAPError("SearchUAC", server, ...) for any other search error
+//
+// server is passed through to WrapLDAPError; in production this is
+// l.config.Server.
+func classifyUACSearchResult(sr *ldap.SearchResult, searchErr error, dn string, notFoundErr error, server string) (*ldap.Entry, error) {
+	if searchErr != nil {
+		// AD typically reports a missing DN as LDAPResultNoSuchObject
+		// on the search itself rather than an empty result set. Map
+		// that to the caller-supplied sentinel so the error shape
+		// matches the rest of the API (FindUserByDN, FindComputerByDN).
+		var ldapErr *ldap.Error
+		if errors.As(searchErr, &ldapErr) && ldapErr.ResultCode == ldap.LDAPResultNoSuchObject {
+			return nil, fmt.Errorf("%w: %s", notFoundErr, dn)
+		}
+		return nil, WrapLDAPError("SearchUAC", server, searchErr)
+	}
+	if sr == nil || len(sr.Entries) == 0 {
+		return nil, fmt.Errorf("%w: %s", notFoundErr, dn)
+	}
+	return sr.Entries[0], nil
+}
+
+// applyUACBitToEntry computes the new userAccountControl value for a
+// single LDAP entry. Pure function — no I/O. Returns:
+//
+//   - current: the parsed current UAC value
+//   - next:    current with bit set or cleared per `set`
+//   - changed: true iff next != current (caller can short-circuit
+//     the Modify when this is false)
+//   - err:     non-nil when the entry has no userAccountControl
+//     attribute (not AD), or when the attribute value can't be parsed
+//     as uint32. Both shapes match what updateUACBit returned before
+//     extraction.
+//
+// The dn is taken from entry.DN for error messages; entry.DN is
+// always populated by go-ldap on a base-object search.
+func applyUACBitToEntry(entry *ldap.Entry, bit uint32, set bool) (current, next uint32, changed bool, err error) {
+	raw := entry.GetAttributeValue("userAccountControl")
+	if raw == "" {
+		// No userAccountControl on the entry — only AD has this
+		// attribute. Return a clear error so OpenLDAP callers get a
+		// useful message instead of a silent no-op.
+		return 0, 0, false, fmt.Errorf("userAccountControl attribute missing on %s (not an Active Directory entry?)", entry.DN)
+	}
+	current64, parseErr := strconv.ParseUint(raw, 10, 32)
+	if parseErr != nil {
+		return 0, 0, false, fmt.Errorf("parse userAccountControl %q on %s: %w", raw, entry.DN, parseErr)
+	}
+	current = uint32(current64)
+	if set {
+		next = current | bit
+	} else {
+		next = current &^ bit
+	}
+	return current, next, next != current, nil
 }

--- a/disable_test.go
+++ b/disable_test.go
@@ -3,11 +3,15 @@
 package ldap
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"log/slog"
 	"testing"
 
+	"github.com/go-ldap/ldap/v3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestACCOUNTDISABLEConstant is a documentation test — it locks in the
@@ -142,4 +146,237 @@ func TestUpdateUACBit_BitArithmetic(t *testing.T) {
 				tc.current, tc.bit, tc.set)
 		})
 	}
+}
+
+// TestClassifyUACSearchResult covers the search-result error mapping
+// extracted from updateUACBit. These branches were unreachable in
+// PR #167's tests because the offline server short-circuits in
+// createDirectConnection before any Search call is attempted.
+func TestClassifyUACSearchResult(t *testing.T) {
+	const (
+		dn     = "cn=test,dc=example,dc=com"
+		server = "ldap://test:389"
+	)
+
+	t.Run("LDAPResultNoSuchObject maps to caller-supplied sentinel (user)", func(t *testing.T) {
+		searchErr := ldap.NewError(ldap.LDAPResultNoSuchObject, errors.New("0000208D: NameErr: DSID-..."))
+
+		entry, mapErr := classifyUACSearchResult(nil, searchErr, dn, ErrUserNotFound, server)
+
+		assert.Nil(t, entry)
+		require.Error(t, mapErr)
+		assert.ErrorIs(t, mapErr, ErrUserNotFound)
+		assert.Contains(t, mapErr.Error(), dn)
+	})
+
+	t.Run("LDAPResultNoSuchObject maps to ErrComputerNotFound when caller passes it", func(t *testing.T) {
+		searchErr := ldap.NewError(ldap.LDAPResultNoSuchObject, errors.New("not found"))
+
+		entry, mapErr := classifyUACSearchResult(nil, searchErr, dn, ErrComputerNotFound, server)
+
+		assert.Nil(t, entry)
+		require.Error(t, mapErr)
+		assert.ErrorIs(t, mapErr, ErrComputerNotFound)
+		assert.NotErrorIs(t, mapErr, ErrUserNotFound, "must not surface ErrUserNotFound for computer callers")
+	})
+
+	t.Run("non-NoSuchObject error wraps via WrapLDAPError", func(t *testing.T) {
+		// Use a different LDAP error code (insufficient access) — must
+		// fall through to the WrapLDAPError branch, not the sentinel branch.
+		searchErr := ldap.NewError(ldap.LDAPResultInsufficientAccessRights, errors.New("permission denied"))
+
+		entry, mapErr := classifyUACSearchResult(nil, searchErr, dn, ErrUserNotFound, server)
+
+		assert.Nil(t, entry)
+		require.Error(t, mapErr)
+		assert.NotErrorIs(t, mapErr, ErrUserNotFound, "non-NoSuchObject must NOT map to the not-found sentinel")
+		assert.Contains(t, mapErr.Error(), "SearchUAC", "must wrap via WrapLDAPError with operation 'SearchUAC'")
+	})
+
+	t.Run("non-LDAP error wraps via WrapLDAPError", func(t *testing.T) {
+		// A plain Go error (network failure, etc.) — also goes through
+		// the WrapLDAPError branch.
+		searchErr := errors.New("dial tcp: i/o timeout")
+
+		entry, mapErr := classifyUACSearchResult(nil, searchErr, dn, ErrUserNotFound, server)
+
+		assert.Nil(t, entry)
+		require.Error(t, mapErr)
+		assert.NotErrorIs(t, mapErr, ErrUserNotFound)
+		assert.Contains(t, mapErr.Error(), "SearchUAC")
+	})
+
+	t.Run("empty result set maps to caller-supplied sentinel", func(t *testing.T) {
+		// Some directories return success + 0 entries instead of
+		// LDAPResultNoSuchObject for a missing DN. Both shapes must
+		// surface as the same sentinel.
+		emptySr := &ldap.SearchResult{Entries: []*ldap.Entry{}}
+
+		entry, mapErr := classifyUACSearchResult(emptySr, nil, dn, ErrUserNotFound, server)
+
+		assert.Nil(t, entry)
+		require.Error(t, mapErr)
+		assert.ErrorIs(t, mapErr, ErrUserNotFound)
+		assert.Contains(t, mapErr.Error(), dn)
+	})
+
+	t.Run("nil SearchResult with no error treated as not-found", func(t *testing.T) {
+		// Defensive: if the caller somehow passes (nil, nil) we must
+		// not panic; treat it as not-found rather than crashing.
+		entry, mapErr := classifyUACSearchResult(nil, nil, dn, ErrUserNotFound, server)
+
+		assert.Nil(t, entry)
+		require.Error(t, mapErr)
+		assert.ErrorIs(t, mapErr, ErrUserNotFound)
+	})
+
+	t.Run("single matching entry returned unchanged", func(t *testing.T) {
+		want := &ldap.Entry{
+			DN: dn,
+			Attributes: []*ldap.EntryAttribute{
+				{Name: "userAccountControl", Values: []string{"514"}},
+			},
+		}
+		sr := &ldap.SearchResult{Entries: []*ldap.Entry{want}}
+
+		got, mapErr := classifyUACSearchResult(sr, nil, dn, ErrUserNotFound, server)
+
+		require.NoError(t, mapErr)
+		assert.Same(t, want, got)
+	})
+}
+
+// TestApplyUACBitToEntry covers the read-modify branches extracted
+// from updateUACBit: missing attribute, parse failure, set/clear
+// arithmetic, and the no-op short-circuit when the bit is already
+// in the desired state.
+func TestApplyUACBitToEntry(t *testing.T) {
+	t.Run("missing userAccountControl attribute", func(t *testing.T) {
+		// OpenLDAP entries don't have userAccountControl; must error
+		// loudly instead of silently treating it as 0.
+		entry := &ldap.Entry{DN: "cn=ol,dc=example,dc=com", Attributes: nil}
+
+		_, _, _, err := applyUACBitToEntry(entry, ACCOUNTDISABLE, true)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "userAccountControl attribute missing")
+		assert.Contains(t, err.Error(), entry.DN)
+	})
+
+	t.Run("attribute present but unparseable", func(t *testing.T) {
+		// AD always populates a uint32; if we see "garbage" we want
+		// the parse error wrapped with context, not a misleading 0.
+		entry := &ldap.Entry{
+			DN:         "cn=bad,dc=example,dc=com",
+			Attributes: []*ldap.EntryAttribute{{Name: "userAccountControl", Values: []string{"not-a-number"}}},
+		}
+
+		_, _, _, err := applyUACBitToEntry(entry, ACCOUNTDISABLE, true)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "parse userAccountControl")
+		assert.Contains(t, err.Error(), "not-a-number")
+		assert.Contains(t, err.Error(), entry.DN)
+	})
+
+	t.Run("set ACCOUNTDISABLE on a NORMAL_ACCOUNT (changes)", func(t *testing.T) {
+		entry := &ldap.Entry{
+			DN:         "cn=u,dc=example,dc=com",
+			Attributes: []*ldap.EntryAttribute{{Name: "userAccountControl", Values: []string{"512"}}}, // 0x200 NORMAL
+		}
+
+		current, next, changed, err := applyUACBitToEntry(entry, ACCOUNTDISABLE, true)
+
+		require.NoError(t, err)
+		assert.Equal(t, uint32(0x200), current)
+		assert.Equal(t, uint32(0x202), next)
+		assert.True(t, changed)
+	})
+
+	t.Run("set ACCOUNTDISABLE when already set is a no-op", func(t *testing.T) {
+		entry := &ldap.Entry{
+			DN:         "cn=u,dc=example,dc=com",
+			Attributes: []*ldap.EntryAttribute{{Name: "userAccountControl", Values: []string{"514"}}}, // NORMAL | DISABLED
+		}
+
+		current, next, changed, err := applyUACBitToEntry(entry, ACCOUNTDISABLE, true)
+
+		require.NoError(t, err)
+		assert.Equal(t, uint32(0x202), current)
+		assert.Equal(t, uint32(0x202), next)
+		assert.False(t, changed, "no-op when bit already set — caller must skip Modify")
+	})
+
+	t.Run("clear ACCOUNTDISABLE preserves unrelated bits", func(t *testing.T) {
+		entry := &ldap.Entry{
+			DN:         "cn=u,dc=example,dc=com",
+			Attributes: []*ldap.EntryAttribute{{Name: "userAccountControl", Values: []string{"66050"}}}, // 0x10202 NORMAL+DISABLED+NO_PASSWORD_EXPIRATION
+		}
+
+		current, next, changed, err := applyUACBitToEntry(entry, ACCOUNTDISABLE, false)
+
+		require.NoError(t, err)
+		assert.Equal(t, uint32(0x10202), current)
+		assert.Equal(t, uint32(0x10200), next, "must preserve NORMAL + NO_PASSWORD_EXPIRATION while clearing DISABLED")
+		assert.True(t, changed)
+	})
+
+	t.Run("clear ACCOUNTDISABLE when already cleared is a no-op", func(t *testing.T) {
+		entry := &ldap.Entry{
+			DN:         "cn=u,dc=example,dc=com",
+			Attributes: []*ldap.EntryAttribute{{Name: "userAccountControl", Values: []string{"512"}}}, // NORMAL only
+		}
+
+		current, next, changed, err := applyUACBitToEntry(entry, ACCOUNTDISABLE, false)
+
+		require.NoError(t, err)
+		assert.Equal(t, uint32(0x200), current)
+		assert.Equal(t, uint32(0x200), next)
+		assert.False(t, changed)
+	})
+}
+
+// TestLogConnectionReleaseError covers the defer log path that fires
+// when ReleaseConnection() returns an error. nil-error must be silent
+// (no spurious log output for the happy path); a real error must
+// produce a structured slog.Debug record with operation + error fields.
+func TestLogConnectionReleaseError(t *testing.T) {
+	t.Run("nil err is silent", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+		client := &LDAP{logger: logger}
+
+		client.logConnectionReleaseError("updateUACBit", nil)
+
+		assert.Empty(t, buf.String(), "no log line on the success path")
+	})
+
+	t.Run("real error is logged with operation and message", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+		client := &LDAP{logger: logger}
+
+		client.logConnectionReleaseError("updateUACBit", errors.New("pool closed"))
+
+		out := buf.String()
+		assert.Contains(t, out, "connection_close_error")
+		assert.Contains(t, out, "operation=updateUACBit")
+		assert.Contains(t, out, `error="pool closed"`)
+		assert.Contains(t, out, "level=DEBUG", "must use Debug level so prod logs aren't spammed")
+	})
+
+	t.Run("operation field reflects the caller's value", func(t *testing.T) {
+		// The helper takes an operation string so callers from
+		// different code paths can be distinguished in the log.
+		// updateUACBit passes "updateUACBit"; verify that custom
+		// values flow through unchanged so future callers don't
+		// accidentally hard-code one operation name.
+		var buf bytes.Buffer
+		logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+		client := &LDAP{logger: logger}
+
+		client.logConnectionReleaseError("custom-op-name", errors.New("oops"))
+
+		assert.Contains(t, buf.String(), "operation=custom-op-name")
+	})
 }


### PR DESCRIPTION
Follow-up to #167: properly cover the new `updateUACBit` paths so codecov/patch reaches the project target instead of the 35.71% it landed at.

## Why the gap existed

PR #167 added three new branches:
- `LDAPResultNoSuchObject` → caller-supplied sentinel mapping
- empty-result-set → same sentinel
- `ReleaseConnection` error → `l.logger.Debug(...)` log line

None were reachable from unit tests because:
- The offline-server smoke test short-circuits in `createDirectConnection` *before* any `Search` is attempted, so the search-result branches were never touched.
- The release-log was inside a defer closure with no seam for assertions.

## Refactor

Three pure helpers carved out, leaving `updateUACBit` as a thin orchestrator:

| Helper | Purpose | New coverage |
|---|---|---|
| `classifyUACSearchResult` | (SearchResult, error) → entry / sentinel / wrap | 100% |
| `applyUACBitToEntry` | entry + bit + set → (current, next, changed, err) | 100% |
| `logConnectionReleaseError` | release-error → `slog.Debug` (silent on nil) | 100% |

`updateUACBit` itself drops to 18.8% statement coverage but every meaningful branch now lives in a unit-tested pure function. The remaining glue (conn pool, real `Search` call, real `ModifyUser`) requires a live LDAP server and is the integration suite's job.

## Tests added (16 subtests across 3 functions)

`TestClassifyUACSearchResult`:
- LDAPResultNoSuchObject → `ErrUserNotFound` (user caller)
- LDAPResultNoSuchObject → `ErrComputerNotFound` (computer caller; explicitly asserts not-ErrUserNotFound)
- LDAPResultInsufficientAccessRights → `SearchUAC` wrap (not the sentinel)
- non-LDAP error (network) → `SearchUAC` wrap
- empty result set → sentinel
- nil-SearchResult / nil-error defensive → sentinel
- single matching entry → unchanged pass-through

`TestApplyUACBitToEntry`:
- missing userAccountControl attribute (OpenLDAP) → loud error
- unparseable attribute value → wrapped parse error
- set on NORMAL_ACCOUNT → 0x202 (changed=true)
- set when already set → no-op (changed=false)
- clear preserves NO_PASSWORD_EXPIRATION etc.
- clear when already cleared → no-op

`TestLogConnectionReleaseError`:
- nil error is silent (no spurious log line on success)
- real error logs at Debug with operation + error fields
- operation field reflects caller value (covers future call sites)

## Verification

```
$ go build ./...   # clean
$ go vet ./...     # clean
$ go test -count=1 -timeout=60s ./...
ok  	github.com/netresearch/simple-ldap-go	59.316s	coverage: 78.9% of statements
```

All 16 new subtests pass; existing 11 (TestACCOUNTDISABLEConstant, TestDisableEnableUser_NoConnection × 5, TestUpdateUACBit_BitArithmetic × 6) still pass. No behaviour change in `updateUACBit`.