### PR TITLE
fix(auth): stop writing unicodePwd on non-Active-Directory servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Password writes no longer assume Active Directory.** `ChangePasswordForSAMAccountName` and `ResetPasswordForSAMAccountName` (and their `*Context` variants) wrote the Microsoft-specific `unicodePwd` attribute unconditionally, with no branch on `Config.IsActiveDirectory`. OpenLDAP and other non-AD directories have no such attribute and rejected every write with `LDAP Result Code 17 "Undefined Attribute Type"`, so no password could be changed or reset on them at all — the failure was total, on the first attempt, with no configuration that avoided it. Both paths now branch: Active Directory keeps the `unicodePwd` write (DELETE+ADD for a self-service change, REPLACE for an administrative reset), and every other directory uses the RFC 3062 Password Modify extended operation, which also lets the server apply its configured hashing scheme instead of storing whatever the client sends. The AD-only UTF-16LE encoding is no longer applied on the non-AD path, where it would corrupt the password.
+- `CreateUser` already gated AD-only attributes on `IsActiveDirectory` for exactly this failure mode; the password paths had never received the same treatment.
+
+### Added
+
+- Integration coverage for password writes against a real OpenLDAP container (`auth_openldap_integration_test.go`). It binds with the new password after each write rather than only asserting the call returned no error — the previous mock-only coverage could not distinguish "the server accepted the request" from "the password actually changed", which is why the `unicodePwd` defect went unnoticed.
+- Warning log `password_write_over_cleartext_connection` when a non-AD password write goes over an unencrypted `ldap://` connection. The RFC 3062 request carries the new password in the clear, and since these writes previously always failed, this is the first release in which such a deployment can work at all. Active Directory is still refused outright (`ErrActiveDirectoryMustBeLDAPS`); non-AD only warns, because plain `ldap://` behind an already-encrypted transport is a legitimate setup and failing would break working deployments.
+
 ---
 
 ## [v1.12.0] - 2026-04-22

--- a/auth.go
+++ b/auth.go
@@ -19,6 +19,27 @@ var (
 	ErrActiveDirectoryMustBeLDAPS = errors.New("ActiveDirectory servers must be connected to via LDAPS to change passwords")
 )
 
+// warnCleartextPasswordWrite logs when a non-AD password write is about to go
+// over an unencrypted connection.
+//
+// Active Directory is refused outright in that situation (ErrActiveDirectoryMustBeLDAPS).
+// Non-AD directories are not, because plain ldap:// is a legitimate setup behind
+// a trusted transport — a stunnel/service-mesh sidecar, or a loopback-only test
+// stack. But the RFC 3062 request carries the new password in the clear, so an
+// operator who did not intend that should hear about it. This warns rather than
+// failing so existing deployments keep working.
+func (l *LDAP) warnCleartextPasswordWrite(operation, maskedUsername string) {
+	if l.config.IsActiveDirectory || strings.HasPrefix(l.config.Server, "ldaps://") {
+		return
+	}
+	l.logger.Warn("password_write_over_cleartext_connection",
+		slog.String("operation", operation),
+		slog.String("username_masked", maskedUsername),
+		slog.String("server", l.config.Server),
+		slog.String("risk", "the new password is transmitted unencrypted"),
+		slog.String("recommendation", "use ldaps:// or StartTLS, or ensure the transport is otherwise encrypted"))
+}
+
 // CheckPasswordForSAMAccountName validates a user's password by attempting to bind with their credentials.
 // This method finds the user by their sAMAccountName and then attempts authentication.
 //
@@ -441,6 +462,7 @@ func (l *LDAP) ChangePasswordForSAMAccountNameContext(ctx context.Context, sAMAc
 			slog.String("server", l.config.Server))
 		return ErrActiveDirectoryMustBeLDAPS
 	}
+	l.warnCleartextPasswordWrite("ChangePasswordForSAMAccountName", maskedUsername)
 
 	// Check for context cancellation before starting
 	select {
@@ -463,15 +485,20 @@ func (l *LDAP) ChangePasswordForSAMAccountNameContext(ctx context.Context, sAMAc
 		return fmt.Errorf("failed to find user %s for password change: %w", sAMAccountName, err)
 	}
 
-	// Encode both passwords for Active Directory
-	oldEncoded, newEncoded, err := l.encodePasswordPair(oldCreds, newCreds, sAMAccountName)
-	if err != nil {
-		l.logger.Error("password_change_encoding_failed",
-			slog.String("operation", "ChangePasswordForSAMAccountName"),
-			slog.String("username_masked", maskedUsername),
-			slog.String("error", err.Error()),
-			slog.Duration("duration", time.Since(start)))
-		return fmt.Errorf("failed to encode passwords for user %s: %w", sAMAccountName, err)
+	// Only Active Directory needs the UTF-16LE encoding: it is a property of the
+	// unicodePwd attribute, not of LDAP. Directories reached over RFC 3062 take
+	// the plaintext and hash it server-side, so encoding there would corrupt it.
+	var oldEncoded, newEncoded string
+	if l.config.IsActiveDirectory {
+		oldEncoded, newEncoded, err = l.encodePasswordPair(oldCreds, newCreds, sAMAccountName)
+		if err != nil {
+			l.logger.Error("password_change_encoding_failed",
+				slog.String("operation", "ChangePasswordForSAMAccountName"),
+				slog.String("username_masked", maskedUsername),
+				slog.String("error", err.Error()),
+				slog.Duration("duration", time.Since(start)))
+			return fmt.Errorf("failed to encode passwords for user %s: %w", sAMAccountName, err)
+		}
 	}
 
 	// Check for context cancellation before LDAP operations
@@ -496,16 +523,29 @@ func (l *LDAP) ChangePasswordForSAMAccountNameContext(ctx context.Context, sAMAc
 		}
 	}()
 
-	// Create modify request for password change
 	userDN := user.DN()
-	modifyRequest := ldap.NewModifyRequest(userDN, nil)
 
-	// Delete old password and add new password (Microsoft's recommended approach)
-	modifyRequest.Delete("unicodePwd", []string{oldEncoded})
-	modifyRequest.Add("unicodePwd", []string{newEncoded})
+	if l.config.IsActiveDirectory {
+		// Active Directory does not implement RFC 3062 and requires writing the
+		// Microsoft-specific unicodePwd attribute. DELETE old + ADD new is
+		// Microsoft's documented approach for a self-service change: it proves
+		// knowledge of the current password without granting reset rights.
+		modifyRequest := ldap.NewModifyRequest(userDN, nil)
+		modifyRequest.Delete("unicodePwd", []string{oldEncoded})
+		modifyRequest.Add("unicodePwd", []string{newEncoded})
+		err = c.Modify(modifyRequest)
+	} else {
+		// Every other directory (OpenLDAP, 389 DS, …) has no unicodePwd attribute
+		// and rejects that write with result 17 "Undefined Attribute Type". They
+		// implement RFC 3062 Password Modify, which also lets the server apply its
+		// configured hashing scheme rather than storing whatever the client sends.
+		// Passing the old password lets the server enforce password policy
+		// (history, minimum age) on a self-service change.
+		_, oldPlain := oldCreds.GetCredentials()
+		_, newPlain := newCreds.GetCredentials()
+		_, err = c.PasswordModify(ldap.NewPasswordModifyRequest(userDN, oldPlain, newPlain))
+	}
 
-	// Perform the password change
-	err = c.Modify(modifyRequest)
 	if err != nil {
 		l.logger.Error("password_change_failed",
 			slog.String("operation", "ChangePasswordForSAMAccountName"),
@@ -565,11 +605,17 @@ func (l *LDAP) ResetPasswordForSAMAccountNameContext(ctx context.Context, sAMAcc
 
 	start := time.Now()
 
-	// Encode new password for LDAP (UTF-16LE with quotes)
-	// For admin reset, we don't need SecureCredential validation - just encoding
-	newEncoded, err := encodePassword(newPassword)
-	if err != nil {
-		return fmt.Errorf("failed to encode new password: %w", err)
+	// Encode the new password for Active Directory (UTF-16LE with quotes).
+	// For admin reset, we don't need SecureCredential validation - just encoding.
+	// Non-AD directories take the plaintext over RFC 3062 and hash it themselves,
+	// so this encoding must not be applied to them.
+	var newEncoded string
+	if l.config.IsActiveDirectory {
+		var err error
+		newEncoded, err = encodePassword(newPassword)
+		if err != nil {
+			return fmt.Errorf("failed to encode new password: %w", err)
+		}
 	}
 
 	// Mask sensitive data for logging
@@ -587,6 +633,7 @@ func (l *LDAP) ResetPasswordForSAMAccountNameContext(ctx context.Context, sAMAcc
 			slog.String("server", l.config.Server))
 		return ErrActiveDirectoryMustBeLDAPS
 	}
+	l.warnCleartextPasswordWrite("ResetPasswordForSAMAccountName", maskedUsername)
 
 	// Check for context cancellation before starting
 	select {
@@ -626,14 +673,22 @@ func (l *LDAP) ResetPasswordForSAMAccountNameContext(ctx context.Context, sAMAcc
 	}
 	defer func() { _ = l.ReleaseConnection(c) }()
 
-	// Create modify request - REPLACE operation for administrative reset
-	// This is different from password change which uses DELETE+ADD
 	userDN := user.DN()
-	modifyRequest := ldap.NewModifyRequest(userDN, nil)
-	modifyRequest.Replace("unicodePwd", []string{newEncoded})
 
-	// Execute modify operation
-	err = c.Modify(modifyRequest)
+	if l.config.IsActiveDirectory {
+		// REPLACE for an administrative reset — unlike a self-service change, the
+		// caller does not know the current password and is instead bound as an
+		// account holding reset rights.
+		modifyRequest := ldap.NewModifyRequest(userDN, nil)
+		modifyRequest.Replace("unicodePwd", []string{newEncoded})
+		err = c.Modify(modifyRequest)
+	} else {
+		// RFC 3062 with an empty old password: the directory authorises the change
+		// from the bound service account's rights rather than from knowledge of the
+		// existing password. See the AD branch above for why this split exists.
+		_, err = c.PasswordModify(ldap.NewPasswordModifyRequest(userDN, "", newPassword))
+	}
+
 	if err != nil {
 		l.logger.Error("password_reset_modify_failed",
 			slog.String("operation", "ResetPasswordForSAMAccountName"),

--- a/auth.go
+++ b/auth.go
@@ -19,6 +19,53 @@ var (
 	ErrActiveDirectoryMustBeLDAPS = errors.New("ActiveDirectory servers must be connected to via LDAPS to change passwords")
 )
 
+// passwordWrite carries the values a single password write needs, in both the
+// forms the two directory families require.
+//
+// An empty oldEncoded/oldPassword marks an administrative reset: the caller does
+// not know the current password and is authorised by the rights of the account
+// it is bound as, rather than by knowledge of the existing secret.
+type passwordWrite struct {
+	userDN string
+
+	// Active Directory path: UTF-16LE, quote-wrapped values for unicodePwd.
+	oldEncoded string
+	newEncoded string
+
+	// RFC 3062 path: plaintext, hashed server-side by the directory.
+	oldPassword string
+	newPassword string
+}
+
+// writePassword applies a password change using the mechanism the directory
+// actually supports.
+//
+// Active Directory does not implement RFC 3062 and requires writing the
+// Microsoft-specific unicodePwd attribute. Every other directory (OpenLDAP,
+// 389 DS, …) has no such attribute and rejects that write with result 17
+// "Undefined Attribute Type"; they implement RFC 3062 Password Modify, which
+// additionally lets the server apply its configured hashing scheme instead of
+// storing whatever the client sends.
+func (l *LDAP) writePassword(c *ldap.Conn, w passwordWrite) error {
+	if !l.config.IsActiveDirectory {
+		_, err := c.PasswordModify(ldap.NewPasswordModifyRequest(w.userDN, w.oldPassword, w.newPassword))
+		return err
+	}
+
+	modifyRequest := ldap.NewModifyRequest(w.userDN, nil)
+	if w.oldEncoded == "" {
+		// Administrative reset.
+		modifyRequest.Replace("unicodePwd", []string{w.newEncoded})
+	} else {
+		// Self-service change: DELETE old + ADD new is Microsoft's documented
+		// approach — it proves knowledge of the current password without
+		// requiring reset rights.
+		modifyRequest.Delete("unicodePwd", []string{w.oldEncoded})
+		modifyRequest.Add("unicodePwd", []string{w.newEncoded})
+	}
+	return c.Modify(modifyRequest)
+}
+
 // warnCleartextPasswordWrite logs when a non-AD password write is about to go
 // over an unencrypted connection.
 //
@@ -523,29 +570,19 @@ func (l *LDAP) ChangePasswordForSAMAccountNameContext(ctx context.Context, sAMAc
 		}
 	}()
 
+	// Supplying the old password lets a non-AD server enforce password policy
+	// (history, minimum age) on a self-service change.
+	_, oldPlain := oldCreds.GetCredentials()
+	_, newPlain := newCreds.GetCredentials()
+
 	userDN := user.DN()
-
-	if l.config.IsActiveDirectory {
-		// Active Directory does not implement RFC 3062 and requires writing the
-		// Microsoft-specific unicodePwd attribute. DELETE old + ADD new is
-		// Microsoft's documented approach for a self-service change: it proves
-		// knowledge of the current password without granting reset rights.
-		modifyRequest := ldap.NewModifyRequest(userDN, nil)
-		modifyRequest.Delete("unicodePwd", []string{oldEncoded})
-		modifyRequest.Add("unicodePwd", []string{newEncoded})
-		err = c.Modify(modifyRequest)
-	} else {
-		// Every other directory (OpenLDAP, 389 DS, …) has no unicodePwd attribute
-		// and rejects that write with result 17 "Undefined Attribute Type". They
-		// implement RFC 3062 Password Modify, which also lets the server apply its
-		// configured hashing scheme rather than storing whatever the client sends.
-		// Passing the old password lets the server enforce password policy
-		// (history, minimum age) on a self-service change.
-		_, oldPlain := oldCreds.GetCredentials()
-		_, newPlain := newCreds.GetCredentials()
-		_, err = c.PasswordModify(ldap.NewPasswordModifyRequest(userDN, oldPlain, newPlain))
-	}
-
+	err = l.writePassword(c, passwordWrite{
+		userDN:      userDN,
+		oldEncoded:  oldEncoded,
+		newEncoded:  newEncoded,
+		oldPassword: oldPlain,
+		newPassword: newPlain,
+	})
 	if err != nil {
 		l.logger.Error("password_change_failed",
 			slog.String("operation", "ChangePasswordForSAMAccountName"),
@@ -673,22 +710,14 @@ func (l *LDAP) ResetPasswordForSAMAccountNameContext(ctx context.Context, sAMAcc
 	}
 	defer func() { _ = l.ReleaseConnection(c) }()
 
+	// Empty old password marks this as an administrative reset: authorised by the
+	// rights of the bound service account, not by knowledge of the current secret.
 	userDN := user.DN()
-
-	if l.config.IsActiveDirectory {
-		// REPLACE for an administrative reset — unlike a self-service change, the
-		// caller does not know the current password and is instead bound as an
-		// account holding reset rights.
-		modifyRequest := ldap.NewModifyRequest(userDN, nil)
-		modifyRequest.Replace("unicodePwd", []string{newEncoded})
-		err = c.Modify(modifyRequest)
-	} else {
-		// RFC 3062 with an empty old password: the directory authorises the change
-		// from the bound service account's rights rather than from knowledge of the
-		// existing password. See the AD branch above for why this split exists.
-		_, err = c.PasswordModify(ldap.NewPasswordModifyRequest(userDN, "", newPassword))
-	}
-
+	err = l.writePassword(c, passwordWrite{
+		userDN:      userDN,
+		newEncoded:  newEncoded,
+		newPassword: newPassword,
+	})
 	if err != nil {
 		l.logger.Error("password_reset_modify_failed",
 			slog.String("operation", "ResetPasswordForSAMAccountName"),

--- a/auth.go
+++ b/auth.go
@@ -51,19 +51,26 @@ func (l *LDAP) writePassword(c *ldap.Conn, w passwordWrite) error {
 		_, err := c.PasswordModify(ldap.NewPasswordModifyRequest(w.userDN, w.oldPassword, w.newPassword))
 		return err
 	}
+	return c.Modify(buildADPasswordModify(w))
+}
 
+// buildADPasswordModify constructs the unicodePwd modify request for Active
+// Directory. Split out from writePassword so the choice of operation can be
+// asserted without a live connection.
+//
+// An empty oldEncoded means an administrative reset, which uses REPLACE. A
+// self-service change instead uses DELETE old + ADD new — Microsoft's documented
+// approach, which proves knowledge of the current password and so does not
+// require the caller to hold reset rights.
+func buildADPasswordModify(w passwordWrite) *ldap.ModifyRequest {
 	modifyRequest := ldap.NewModifyRequest(w.userDN, nil)
 	if w.oldEncoded == "" {
-		// Administrative reset.
 		modifyRequest.Replace("unicodePwd", []string{w.newEncoded})
-	} else {
-		// Self-service change: DELETE old + ADD new is Microsoft's documented
-		// approach — it proves knowledge of the current password without
-		// requiring reset rights.
-		modifyRequest.Delete("unicodePwd", []string{w.oldEncoded})
-		modifyRequest.Add("unicodePwd", []string{w.newEncoded})
+		return modifyRequest
 	}
-	return c.Modify(modifyRequest)
+	modifyRequest.Delete("unicodePwd", []string{w.oldEncoded})
+	modifyRequest.Add("unicodePwd", []string{w.newEncoded})
+	return modifyRequest
 }
 
 // warnCleartextPasswordWrite logs when a non-AD password write is about to go

--- a/auth_openldap_integration_test.go
+++ b/auth_openldap_integration_test.go
@@ -1,0 +1,104 @@
+//go:build integration
+// +build integration
+
+package ldap
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/go-ldap/ldap/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// bindAs proves a password is live by opening a fresh connection and binding as
+// the user. Asserting on the write call's error alone is not enough: it would
+// still pass if the server accepted a write that did not actually take effect.
+func bindAs(t *testing.T, tc *TestContainer, userDN, password string) error {
+	t.Helper()
+
+	conn, err := ldap.DialURL(tc.Config.Server)
+	require.NoError(t, err, "dial for bind check")
+	defer func() { _ = conn.Close() }()
+
+	return conn.Bind(userDN, password)
+}
+
+// TestIntegration_OpenLDAP_PasswordWrites is a regression test for password
+// writes against a non-Active-Directory server.
+//
+// Both password paths used to write the Microsoft-specific unicodePwd attribute
+// unconditionally, with no branch on Config.IsActiveDirectory. OpenLDAP has no
+// such attribute, so every write failed with LDAP result 17 "Undefined Attribute
+// Type" and no password could ever be changed or reset on a non-AD directory.
+//
+// Nothing caught it because every other test either mocks the connection or only
+// performs lookups. This test drives a real OpenLDAP server and then binds with
+// the new password, which is the only assertion that distinguishes "the server
+// accepted our request" from "the password actually changed".
+func TestIntegration_OpenLDAP_PasswordWrites(t *testing.T) {
+	tc := SetupTestContainer(t)
+	defer tc.Close(t)
+
+	td := tc.GetTestData()
+
+	// The harness seeds OpenLDAP, so IsActiveDirectory must be false here. If it
+	// were true the client would take the unicodePwd path and this test would be
+	// asserting nothing about the branch it exists to cover.
+	require.False(t, tc.Config.IsActiveDirectory,
+		"fixture must be a non-AD directory for this regression test to mean anything")
+
+	t.Run("administrative reset sets a usable password", func(t *testing.T) {
+		client, err := New(tc.Config, tc.AdminUser, tc.AdminPass)
+		require.NoError(t, err)
+
+		const newPassword = "Reset1!Password"
+
+		require.NoError(t,
+			client.ResetPasswordForSAMAccountName(td.ValidUserUID, newPassword),
+			"reset must not fail on OpenLDAP (regression: unicodePwd, result 17)")
+
+		assert.NoError(t, bindAs(t, tc, td.ValidUserDN, newPassword),
+			"the new password must actually bind")
+		assert.Error(t, bindAs(t, tc, td.ValidUserDN, td.ValidUserPassword),
+			"the old password must stop working")
+	})
+
+	t.Run("self-service change sets a usable password", func(t *testing.T) {
+		client, err := New(tc.Config, tc.AdminUser, tc.AdminPass)
+		require.NoError(t, err)
+
+		// Start from a known state rather than depending on subtest ordering.
+		const startPassword = "Start1!Password"
+		require.NoError(t, client.ResetPasswordForSAMAccountName(td.DisabledUserUID, startPassword))
+
+		const changedPassword = "Changed1!Password"
+		require.NoError(t,
+			client.ChangePasswordForSAMAccountName(td.DisabledUserUID, startPassword, changedPassword),
+			"change must not fail on OpenLDAP (regression: unicodePwd, result 17)")
+
+		userDN := fmt.Sprintf("uid=%s,%s", td.DisabledUserUID, tc.UsersOU)
+		assert.NoError(t, bindAs(t, tc, userDN, changedPassword),
+			"the changed password must actually bind")
+		assert.Error(t, bindAs(t, tc, userDN, startPassword),
+			"the previous password must stop working")
+	})
+
+	t.Run("change rejects a wrong current password", func(t *testing.T) {
+		client, err := New(tc.Config, tc.AdminUser, tc.AdminPass)
+		require.NoError(t, err)
+
+		const known = "Known1!Password"
+		require.NoError(t, client.ResetPasswordForSAMAccountName(td.ValidUserUID, known))
+
+		// RFC 3062 carries the old password so the server can authorise the change.
+		// Supplying the wrong one must fail, otherwise the change path would be an
+		// unauthenticated reset for anyone who can reach it.
+		err = client.ChangePasswordForSAMAccountName(td.ValidUserUID, "not-the-current-password", "Another1!Password")
+		assert.Error(t, err, "a wrong current password must be rejected")
+
+		assert.NoError(t, bindAs(t, tc, td.ValidUserDN, known),
+			"a rejected change must leave the existing password intact")
+	})
+}

--- a/auth_password_write_test.go
+++ b/auth_password_write_test.go
@@ -1,0 +1,116 @@
+package ldap
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/go-ldap/ldap/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// changeOps flattens a ModifyRequest into (operation, attribute) pairs so a test
+// can assert the shape of the request without reaching for a live connection.
+func changeOps(req *ldap.ModifyRequest) []string {
+	names := map[uint]string{
+		ldap.AddAttribute:     "add",
+		ldap.DeleteAttribute:  "delete",
+		ldap.ReplaceAttribute: "replace",
+	}
+	ops := make([]string, 0, len(req.Changes))
+	for _, c := range req.Changes {
+		ops = append(ops, names[c.Operation]+":"+c.Modification.Type)
+	}
+	return ops
+}
+
+// TestBuildADPasswordModify pins the Active Directory request shape.
+//
+// The distinction matters beyond cosmetics: DELETE+ADD requires the caller to
+// know the current password, so AD authorises it as a self-service change.
+// REPLACE does not, and is only permitted for a caller holding reset rights.
+// Emitting the wrong one silently changes who is allowed to perform the
+// operation, and no OpenLDAP-backed test can catch it.
+func TestBuildADPasswordModify(t *testing.T) {
+	t.Run("administrative reset uses REPLACE", func(t *testing.T) {
+		req := buildADPasswordModify(passwordWrite{
+			userDN:     "CN=jdoe,OU=Users,DC=example,DC=com",
+			newEncoded: "encoded-new",
+		})
+
+		assert.Equal(t, "CN=jdoe,OU=Users,DC=example,DC=com", req.DN)
+		assert.Equal(t, []string{"replace:unicodePwd"}, changeOps(req))
+		require.Len(t, req.Changes, 1)
+		assert.Equal(t, []string{"encoded-new"}, req.Changes[0].Modification.Vals)
+	})
+
+	t.Run("self-service change uses DELETE old then ADD new", func(t *testing.T) {
+		req := buildADPasswordModify(passwordWrite{
+			userDN:     "CN=jdoe,OU=Users,DC=example,DC=com",
+			oldEncoded: "encoded-old",
+			newEncoded: "encoded-new",
+		})
+
+		// Order matters: AD expects the delete of the current value first.
+		assert.Equal(t, []string{"delete:unicodePwd", "add:unicodePwd"}, changeOps(req))
+		require.Len(t, req.Changes, 2)
+		assert.Equal(t, []string{"encoded-old"}, req.Changes[0].Modification.Vals)
+		assert.Equal(t, []string{"encoded-new"}, req.Changes[1].Modification.Vals)
+	})
+
+	t.Run("only unicodePwd is touched", func(t *testing.T) {
+		for _, w := range []passwordWrite{
+			{userDN: "dn", newEncoded: "n"},
+			{userDN: "dn", oldEncoded: "o", newEncoded: "n"},
+		} {
+			for _, c := range buildADPasswordModify(w).Changes {
+				assert.Equal(t, "unicodePwd", c.Modification.Type)
+			}
+		}
+	})
+}
+
+// TestWarnCleartextPasswordWrite covers the guard that fires when a non-AD
+// password write would cross an unencrypted connection. RFC 3062 carries the new
+// password in the request, so this is the operator's only signal.
+func TestWarnCleartextPasswordWrite(t *testing.T) {
+	newLDAP := func(server string, isAD bool, buf *bytes.Buffer) *LDAP {
+		return &LDAP{
+			config: &Config{Server: server, IsActiveDirectory: isAD},
+			logger: slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelWarn})),
+		}
+	}
+
+	tests := []struct {
+		name      string
+		server    string
+		isAD      bool
+		wantWarn  bool
+		reasoning string
+	}{
+		{"non-AD over cleartext warns", "ldap://dir.example.com:389", false, true,
+			"the password crosses the wire unencrypted"},
+		{"non-AD over ldaps stays quiet", "ldaps://dir.example.com:636", false, false,
+			"transport already encrypted"},
+		{"AD is never warned here", "ldap://dc.example.com:389", true, false,
+			"AD is rejected outright by ErrActiveDirectoryMustBeLDAPS before reaching this"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			newLDAP(tt.server, tt.isAD, &buf).warnCleartextPasswordWrite("TestOp", "jd**oe")
+
+			logged := strings.Contains(buf.String(), "password_write_over_cleartext_connection")
+			assert.Equal(t, tt.wantWarn, logged, tt.reasoning)
+
+			if tt.wantWarn {
+				// The warning is useless without the detail an operator acts on.
+				assert.Contains(t, buf.String(), "TestOp")
+				assert.Contains(t, buf.String(), tt.server)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`ChangePasswordForSAMAccountName` and `ResetPasswordForSAMAccountName` (and their `*Context` variants) wrote the Microsoft-specific `unicodePwd` attribute unconditionally. `Config.IsActiveDirectory` was consulted only by the two LDAPS guards (`auth.go:437`, `auth.go:583`) — never to choose the attribute.

OpenLDAP and other non-AD directories have no `unicodePwd` attribute and rejected every write:

```
LDAP Result Code 17 "Undefined Attribute Type": unicodePwd: attribute type undefined
```

So **no password could be changed or reset on a non-AD directory at all.** The failure was total, on the first attempt, and no configuration avoided it:

| Configuration | Outcome before this PR |
| --- | --- |
| `IsActiveDirectory=false` | result 17 — took the `unicodePwd` path anyway |
| `IsActiveDirectory=true` over `ldap://` | refused by the LDAPS guard (`ErrActiveDirectoryMustBeLDAPS`) |
| `IsActiveDirectory=true` over `ldaps://` | result 17 — still wrote `unicodePwd` |

`CreateUser` has gated AD-only attributes on `IsActiveDirectory` since #155, with a comment naming this exact result-17 failure mode (`users.go`). The password paths never received the same treatment.

Found while driving a downstream consumer against its own documented OpenLDAP dev stack: netresearch/ldap-selfservice-password-changer#633.

## Change

Both paths now branch on `Config.IsActiveDirectory`:

- **Active Directory** — unchanged. `unicodePwd` with the UTF-16LE quote-wrapped encoding; DELETE+ADD for a self-service change (Microsoft's documented approach, proving knowledge of the current password), REPLACE for an administrative reset.
- **Everything else** — RFC 3062 Password Modify extended operation, which `go-ldap` already provides (`NewPasswordModifyRequest` / `(*Conn).PasswordModify`). The change path passes the old password so the server can enforce password policy and authorise the change; the reset path passes an empty old password, authorising from the bound service account's rights.

The UTF-16LE encoding is a property of `unicodePwd`, not of LDAP, so it is no longer applied on the non-AD path — it would corrupt the password there. `encodePasswordPair` / `encodePassword` are now only called on the AD branch.

RFC 3062 is also the better mechanism where available: the server applies its configured hashing scheme rather than storing whatever the client sends.

## Test coverage

Adds `auth_openldap_integration_test.go`, driving a real OpenLDAP container via the existing testcontainers harness.

The key design point: each subtest **binds with the new password** after the write, rather than asserting only that the call returned no error. Mock-based tests cannot distinguish "the server accepted the request" from "the password actually changed" — which is precisely why this defect went unnoticed. Existing coverage either mocks the connection or only performs lookups.

Reverting `auth.go` and keeping the test reproduces the original bug exactly:

```
--- FAIL: TestIntegration_OpenLDAP_PasswordWrites/administrative_reset_sets_a_usable_password
    Received unexpected error: ... LDAP Result Code 17 "Undefined Attribute Type": unicodePwd: attribute type undefined
--- FAIL: TestIntegration_OpenLDAP_PasswordWrites/self-service_change_sets_a_usable_password
```

With the fix, all three pass. The third subtest asserts a wrong current password is still rejected and leaves the existing password intact — RFC 3062 must not become an unauthenticated reset.

## Security note

Non-AD password writes previously always failed, so this is the first release in which such a deployment can work — and the RFC 3062 request carries the new password in the clear. Added a `password_write_over_cleartext_connection` warning when a non-AD write goes over plain `ldap://`.

It warns rather than failing: unlike AD, plain `ldap://` behind an already-encrypted transport (stunnel, service mesh, loopback-only test stack) is legitimate, and a hard error would break working deployments. AD remains a hard error via `ErrActiveDirectoryMustBeLDAPS`.

## Verification

```
go build ./...                                              exit 0
go vet ./...                                                exit 0
go test ./...                                               exit 0
golangci-lint run ./...                                     0 issues
gofmt -l auth.go auth_openldap_integration_test.go          (no output)
go test -tags=integration -run TestIntegration_OpenLDAP_PasswordWrites
                                                            ok  11.798s
```

## Compatibility

No API change. Active Directory behaviour is byte-for-byte identical — same attribute, same encoding, same DELETE+ADD / REPLACE split. Only the non-AD path changes, and it previously could not succeed, so there is no working behaviour to regress.
