### PR TITLE
chore(release): v1.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+---
+
+## [v1.12.1] - 2026-07-23
+
 ### Fixed
 
 - **Password writes no longer assume Active Directory.** `ChangePasswordForSAMAccountName` and `ResetPasswordForSAMAccountName` (and their `*Context` variants) wrote the Microsoft-specific `unicodePwd` attribute unconditionally, with no branch on `Config.IsActiveDirectory`. OpenLDAP and other non-AD directories have no such attribute and rejected every write with `LDAP Result Code 17 "Undefined Attribute Type"`, so no password could be changed or reset on them at all — the failure was total, on the first attempt, with no configuration that avoided it. Both paths now branch: Active Directory keeps the `unicodePwd` write (DELETE+ADD for a self-service change, REPLACE for an administrative reset), and every other directory uses the RFC 3062 Password Modify extended operation, which also lets the server apply its configured hashing scheme instead of storing whatever the client sends. The AD-only UTF-16LE encoding is no longer applied on the non-AD path, where it would corrupt the password.


### PR DESCRIPTION
## Description

Stamps the accumulated `[Unreleased]` CHANGELOG entries as `v1.12.1`. No code changes.

## Version choice

Patch, not minor. The 36 commits since `v1.12.0` are 8 `fix`, 5 `ci`, 3 `chore`, 2 `test`, 1 `refactor`, 1 `docs` — no `feat`, and no change to the exported API surface. The password-write fix changes behaviour on non-AD directories but adds no exported symbol: `writePassword`, `buildADPasswordModify` and `passwordWrite` are all unexported.

## What ships

The headline is #182 — `ChangePasswordForSAMAccountName` and `ResetPasswordForSAMAccountName` wrote the Active-Directory-only `unicodePwd` attribute unconditionally, so **no password could be changed or reset on OpenLDAP or any other non-AD directory**. Both paths now branch on `Config.IsActiveDirectory`, with RFC 3062 Password Modify on the non-AD side.

Consumers on OpenLDAP should note this is the first release in which those calls can succeed at all; a `password_write_over_cleartext_connection` warning now fires if such a write crosses a plain `ldap://` connection, since RFC 3062 carries the password in the request.

The remainder is dependency bumps (go-ldap 3.4.14, x/crypto 0.52.0 security, x/text 0.40.0, testcontainers 0.43.0) and CI template syncs.

## After merge

`main` is tagged `v1.12.1` with a signed annotated tag; `release.yml` publishes from the tag via the org reusable workflow.

---

https://claude.ai/code/session_015JAZYAZ9LgWdjrcU9sBFqM
