### PR TITLE
fix(auth): bind as the user for non-AD self-service password change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Self-service password change now binds as the user on non-AD directories.** v1.12.1 stopped `ChangePasswordForSAMAccountName` writing `unicodePwd` to OpenLDAP, but it still issued the RFC 3062 Password Modify on the *pooled* connection — bound as the caller's service account. RFC 3062 authorises a self-service change from the bind identity, so a directory refuses to verify `oldPasswd` for a caller that cannot write the target entry; slapd answers `LDAP Result Code 53 "Unwilling To Perform": unwilling to verify old password`. Any deployment binding a read-only service account (the normal arrangement) therefore still could not change a password. The non-AD path now opens a dedicated connection bound as the user with their current password, which is the flow RFC 3062 describes and which makes the bind itself the proof of the old password. The administrative reset path is unchanged: it legitimately uses the service-account connection with no old password.
+- A wrong current password now fails at the bind rather than at the modify, so the returned error names an authentication failure instead of a server-side refusal.
+
+### Changed
+
+- `createDirectConnection` delegates to a new internal `dialAndBind`, so a connection can be opened under a specific identity. The user-bound connection is deliberately unpooled — binding a pooled connection as an end user would leak that identity to the next caller that borrowed it.
+
+### Added
+
+- The integration harness now provisions a read-only service account (`ReadOnlyDN`/`ReadOnlyPassword`) with a directory-wide read grant. Tests asserting a write must not bind as `cn=admin`: the superuser can write every entry and so masks any defect that depends on the caller's privileges. The v1.12.1 self-service test did exactly that — it passed while real deployments failed. The rewritten test binds as the read-only account and fails against v1.12.1.
+
 ---
 
 ## [v1.12.1] - 2026-07-23

--- a/auth.go
+++ b/auth.go
@@ -577,13 +577,43 @@ func (l *LDAP) ChangePasswordForSAMAccountNameContext(ctx context.Context, sAMAc
 		}
 	}()
 
-	// Supplying the old password lets a non-AD server enforce password policy
-	// (history, minimum age) on a self-service change.
 	_, oldPlain := oldCreds.GetCredentials()
 	_, newPlain := newCreds.GetCredentials()
 
 	userDN := user.DN()
-	err = l.writePassword(c, passwordWrite{
+
+	writeConn := c
+	if !l.config.IsActiveDirectory {
+		// RFC 3062 authorises a self-service change from the BIND IDENTITY, not
+		// from the request contents. A directory refuses to verify oldPasswd for a
+		// caller that lacks write access to the target entry — slapd answers
+		// result 53 "unwilling to verify old password" — so the pooled connection,
+		// bound as the read-only service account, cannot perform this operation.
+		//
+		// Bind as the user instead. That is the flow RFC 3062 describes, and the
+		// bind itself proves knowledge of the current password.
+		//
+		// This must be a dedicated connection: binding a pooled one as an end user
+		// would leak that identity to whichever caller borrows it next.
+		userConn, bindErr := l.dialAndBind(ctx, userDN, oldPlain)
+		if bindErr != nil {
+			l.logger.Warn("password_change_user_bind_failed",
+				slog.String("operation", "ChangePasswordForSAMAccountName"),
+				slog.String("username_masked", maskedUsername),
+				slog.String("dn", userDN),
+				slog.String("error", bindErr.Error()),
+				slog.Duration("duration", time.Since(start)))
+
+			ldapErr := NewLDAPError("ChangePasswordForSAMAccountName", l.config.Server, bindErr).
+				WithDN(userDN).WithContext("samAccountName", sAMAccountName)
+
+			return fmt.Errorf("failed to authenticate user %s for password change: %w", sAMAccountName, ldapErr)
+		}
+		defer func() { _ = userConn.Close() }()
+		writeConn = userConn
+	}
+
+	err = l.writePassword(writeConn, passwordWrite{
 		userDN:      userDN,
 		oldEncoded:  oldEncoded,
 		newEncoded:  newEncoded,

--- a/auth_openldap_integration_test.go
+++ b/auth_openldap_integration_test.go
@@ -65,18 +65,26 @@ func TestIntegration_OpenLDAP_PasswordWrites(t *testing.T) {
 			"the old password must stop working")
 	})
 
-	t.Run("self-service change sets a usable password", func(t *testing.T) {
-		client, err := New(tc.Config, tc.AdminUser, tc.AdminPass)
+	t.Run("self-service change works from an unprivileged service bind", func(t *testing.T) {
+		// The client must NOT be bound as an account with write access to the
+		// target. A real deployment binds a read-only service account, and RFC 3062
+		// authorises a change from the bind identity — so a privileged bind here
+		// would mask the failure that account actually hits. An earlier revision of
+		// this test used tc.AdminUser and passed while production got
+		// result 53 "unwilling to verify old password".
+		admin, err := New(tc.Config, tc.AdminUser, tc.AdminPass)
 		require.NoError(t, err)
 
-		// Start from a known state rather than depending on subtest ordering.
 		const startPassword = "Start1!Password"
-		require.NoError(t, client.ResetPasswordForSAMAccountName(td.DisabledUserUID, startPassword))
+		require.NoError(t, admin.ResetPasswordForSAMAccountName(td.DisabledUserUID, startPassword))
+
+		client, err := New(tc.Config, tc.ReadOnlyDN(), tc.ReadOnlyPassword())
+		require.NoError(t, err, "client bound as a service account that can read but not write")
 
 		const changedPassword = "Changed1!Password"
 		require.NoError(t,
 			client.ChangePasswordForSAMAccountName(td.DisabledUserUID, startPassword, changedPassword),
-			"change must not fail on OpenLDAP (regression: unicodePwd, result 17)")
+			"change must succeed even though the service bind cannot write the target entry")
 
 		userDN := fmt.Sprintf("uid=%s,%s", td.DisabledUserUID, tc.UsersOU)
 		assert.NoError(t, bindAs(t, tc, userDN, changedPassword),

--- a/auth_password_write_test.go
+++ b/auth_password_write_test.go
@@ -2,6 +2,8 @@ package ldap
 
 import (
 	"bytes"
+	"context"
+	"io"
 	"log/slog"
 	"strings"
 	"testing"
@@ -113,4 +115,39 @@ func TestWarnCleartextPasswordWrite(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestDialAndBind_ErrorPaths covers the failure branches of the connection
+// helper that the self-service change path relies on. The happy path is covered
+// by the OpenLDAP integration test; these are the branches a live server never
+// exercises.
+func TestDialAndBind_ErrorPaths(t *testing.T) {
+	newLDAP := func(server string) *LDAP {
+		return &LDAP{
+			config: &Config{Server: server, BaseDN: "dc=example,dc=org"},
+			logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		}
+	}
+
+	t.Run("cancelled context returns before dialing", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		conn, err := newLDAP("ldap://127.0.0.1:1").dialAndBind(ctx, "cn=x,dc=example,dc=org", "pw")
+		require.Error(t, err)
+		assert.Nil(t, conn)
+		assert.ErrorIs(t, err, context.Canceled,
+			"a cancelled context must surface as such, not as a dial failure")
+	})
+
+	t.Run("unreachable server surfaces a dial error", func(t *testing.T) {
+		// Port 1 is reserved and refuses connections, so this fails at dial
+		// rather than hanging.
+		conn, err := newLDAP("ldap://127.0.0.1:1").dialAndBind(
+			context.Background(), "cn=x,dc=example,dc=org", "pw")
+		require.Error(t, err)
+		assert.Nil(t, conn)
+		assert.Contains(t, err.Error(), "failed to dial",
+			"the error must name the dial step so a misconfigured host is diagnosable")
+	})
 }

--- a/client.go
+++ b/client.go
@@ -674,8 +674,21 @@ func (l *LDAP) BulkFindUsersBySAMAccountName(ctx context.Context, samAccountName
 	return result, nil
 }
 
-// createDirectConnection creates a new LDAP connection without using the pool
+// createDirectConnection creates a new LDAP connection without using the pool,
+// bound as the client's configured service account.
 func (l *LDAP) createDirectConnection(ctx context.Context) (*ldap.Conn, error) {
+	return l.dialAndBind(ctx, l.user, l.password)
+}
+
+// dialAndBind creates a new unpooled connection bound as the given identity.
+//
+// Callers that need a specific bind identity — an RFC 3062 self-service password
+// change, which the directory authorises from the bind rather than from the
+// request — must use this rather than the pool. Binding a pooled connection as
+// an end user would leak that identity to whichever caller borrows it next.
+//
+// The returned connection is not managed by the pool; close it directly.
+func (l *LDAP) dialAndBind(ctx context.Context, bindDN, bindPassword string) (*ldap.Conn, error) {
 	// Check context first
 	if err := ctx.Err(); err != nil {
 		return nil, err
@@ -725,11 +738,11 @@ func (l *LDAP) createDirectConnection(ctx context.Context) (*ldap.Conn, error) {
 	}
 
 	// Bind with credentials
-	if err := conn.Bind(l.user, l.password); err != nil {
+	if err := conn.Bind(bindDN, bindPassword); err != nil {
 		_ = conn.Close()
 		l.logger.Error("ldap_bind_failed",
 			slog.String("server", l.config.Server),
-			slog.String("user", l.user),
+			slog.String("user", bindDN),
 			slog.String("error", err.Error()),
 			slog.Duration("duration", time.Since(start)))
 		return nil, fmt.Errorf("failed to bind: %w", err)
@@ -737,7 +750,7 @@ func (l *LDAP) createDirectConnection(ctx context.Context) (*ldap.Conn, error) {
 
 	l.logger.Debug("ldap_connection_established",
 		slog.String("server", l.config.Server),
-		slog.String("user", l.user),
+		slog.String("user", bindDN),
 		slog.Duration("duration", time.Since(start)))
 
 	return conn, nil

--- a/test_setup_test.go
+++ b/test_setup_test.go
@@ -135,6 +135,51 @@ func (tc *TestContainer) populateTestData(t *testing.T) {
 
 	// Create test computers
 	tc.createTestComputers(t, conn)
+
+	// Create a read-only service account and grant it directory-wide read.
+	tc.createReadOnlyServiceAccount(t, conn)
+}
+
+// ReadOnlyDN / ReadOnlyPassword identify a service account that can SEARCH the
+// directory but cannot write any entry.
+//
+// This models how an application actually binds. Tests that assert a write
+// succeeds must not bind as cn=admin: the superuser can write every entry, so it
+// masks any defect that depends on the caller's privileges. An RFC 3062
+// self-service password change is exactly such a case — the directory authorises
+// it from the bind identity, and slapd answers result 53 "unwilling to verify old
+// password" when the bound account cannot write the target.
+func (tc *TestContainer) ReadOnlyDN() string { return fmt.Sprintf("cn=readonly,%s", tc.BaseDN) }
+
+// ReadOnlyPassword is the password for ReadOnlyDN.
+func (tc *TestContainer) ReadOnlyPassword() string { return "readonly123" }
+
+// createReadOnlyServiceAccount adds the account and an olcAccess rule granting it
+// read across the tree. The rule is inserted ahead of the defaults and ends in
+// "by * break" so the container's own ACLs still apply to everyone else.
+func (tc *TestContainer) createReadOnlyServiceAccount(t *testing.T, conn *ldap.Conn) {
+	addReq := ldap.NewAddRequest(tc.ReadOnlyDN(), nil)
+	addReq.Attribute("objectClass", []string{"simpleSecurityObject", "organizationalRole"})
+	addReq.Attribute("cn", []string{"readonly"})
+	addReq.Attribute("description", []string{"Read-only service account for tests"})
+	addReq.Attribute("userPassword", []string{tc.ReadOnlyPassword()})
+	if err := conn.Add(addReq); err != nil {
+		if !ldap.IsErrorWithCode(err, ldap.LDAPResultEntryAlreadyExists) {
+			require.NoError(t, err, "create read-only service account")
+		}
+	}
+
+	// olcAccess lives in cn=config, which takes its own bind.
+	cfgConn, err := ldap.DialURL(tc.Config.Server)
+	require.NoError(t, err, "dial for cn=config")
+	defer func() { _ = cfgConn.Close() }()
+	require.NoError(t, cfgConn.Bind("cn=admin,cn=config", "config123"), "bind cn=config")
+
+	mod := ldap.NewModifyRequest("olcDatabase={1}mdb,cn=config", nil)
+	mod.Add("olcAccess", []string{
+		fmt.Sprintf(`{0}to * by dn="%s" read by * break`, tc.ReadOnlyDN()),
+	})
+	require.NoError(t, cfgConn.Modify(mod), "grant read to the service account")
 }
 
 // createOU creates an organizational unit


### PR DESCRIPTION
## Problem

`v1.12.1` (#182) fixed half of this. It stopped `ChangePasswordForSAMAccountName` writing the AD-only `unicodePwd` attribute to non-AD directories, but it still issued the RFC 3062 Password Modify on the **pooled** connection — the one bound as the caller's service account.

RFC 3062 authorises a self-service change from the **bind identity**, not from the request contents. A directory refuses to verify `oldPasswd` for a caller that cannot write the target entry:

```
LDAP Result Code 53 "Unwilling To Perform": unwilling to verify old password
```

So any deployment binding a read-only service account — the normal arrangement — still could not change a password. Only the administrative reset worked.

Found by driving the downstream consumer against a real OpenLDAP stack after bumping to v1.12.1: the reset completed and the change did not (netresearch/ldap-selfservice-password-changer#633). Isolated with direct `ldappasswd` probes against the same directory: bound as the user → succeeds; bound as a read-only account → identical result 53; bound as an account with write access → succeeds. The operation shape was right; the bind identity was wrong.

## Change

The non-AD change path opens a **dedicated** connection bound as the user with their current password, then issues the extended operation. That is the flow RFC 3062 describes, and the bind is itself the proof of the old password — so a wrong current password now fails at authentication rather than as a server-side refusal, which also gives a more accurate error.

The connection is deliberately **unpooled**. Binding a pooled connection as an end user would leak that identity to whichever caller borrowed it next — a worse bug than the one being fixed.

`createDirectConnection` now delegates to a new internal `dialAndBind(ctx, dn, password)` so a connection can be opened under a specific identity without duplicating the dial/TLS setup.

The administrative reset path is untouched: it legitimately uses the service-account connection with no old password, and is already proven working end to end.

## Why v1.12.1's test did not catch it

It bound as `tc.AdminUser` — `cn=admin`, the directory superuser, which can write every `userPassword`. slapd verified the old password happily and the test passed, while production failed. The test asserted success under privileges the real caller never has.

The harness now provisions a read-only service account (`ReadOnlyDN`/`ReadOnlyPassword`) with a directory-wide read grant, added via `olcAccess` on `cn=config` and terminated with `by * break` so the container's own ACLs still apply to everyone else. The rewritten test binds as that account.

Verified the test is not vacuous: with the new test in place, reverting `auth.go` and `client.go` makes the self-service subtest **fail**, and it passes again once restored.

## Verification

```
go build ./...                                   exit 0
go vet ./...                                     exit 0
go test ./...                                    all packages ok
golangci-lint run ./...                          0 issues
gofmt -l auth.go client.go test_setup_test.go    (no output)

go test -tags=integration -run TestIntegration_OpenLDAP_PasswordWrites
  PASS  administrative_reset_sets_a_usable_password
  PASS  self-service_change_works_from_an_unprivileged_service_bind
  PASS  change_rejects_a_wrong_current_password
```

## Compatibility

No exported API change. Active Directory behaviour is untouched — it still uses the pooled connection and the `unicodePwd` write. Non-AD self-service change goes from always failing to working, so there is no working behaviour to regress. One extra connection is opened per non-AD change; the reset path is unaffected.

---

https://claude.ai/code/session_015JAZYAZ9LgWdjrcU9sBFqM
