### PR TITLE
feat(users): report password expiry for Active Directory and ppolicy

### DIFF
--- a/client.go
+++ b/client.go
@@ -30,6 +30,7 @@ type LDAP struct {
 	connPool         *ConnectionPool
 	circuitBreaker   *CircuitBreaker
 	operationTimeout time.Duration // Timeout for LDAP operations (set via WithTimeout option)
+	policies         *policyCache  // memoised ppolicy pwdMaxAge per policy DN
 }
 
 // Config contains the configuration for LDAP connections
@@ -38,10 +39,17 @@ type Config struct {
 	Port              int
 	BaseDN            string
 	IsActiveDirectory bool
-	TLSConfig         *tls.Config
-	DialTimeout       time.Duration
-	ReadTimeout       time.Duration
-	WriteTimeout      time.Duration
+
+	// PasswordPolicyDN names the OpenLDAP ppolicy entry that governs users
+	// whose own entry carries no pwdPolicySubentry. It is only consulted for
+	// password-expiry lookups on non-Active-Directory servers; Active
+	// Directory reports expiry per user without it. Empty means expiry is
+	// reported as unknown rather than guessed.
+	PasswordPolicyDN string
+	TLSConfig        *tls.Config
+	DialTimeout      time.Duration
+	ReadTimeout      time.Duration
+	WriteTimeout     time.Duration
 
 	// Additional configuration options
 	Pool        *PoolConfig
@@ -127,6 +135,7 @@ func New(config Config, username, password string, opts ...Option) (*LDAP, error
 		user:     username,
 		password: password,
 		logger:   logger,
+		policies: newPolicyCache(),
 	}
 
 	// Apply functional options before initialization

--- a/password_expiry.go
+++ b/password_expiry.go
@@ -1,0 +1,364 @@
+package ldap
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/go-ldap/ldap/v3"
+)
+
+// ErrPasswordPolicyNotFound is returned when the ppolicy entry a user (or the
+// client configuration) points at cannot be read.
+var ErrPasswordPolicyNotFound = errors.New("password policy not found")
+
+// PasswordExpiryStatus classifies what a directory reports about a password's
+// remaining lifetime.
+type PasswordExpiryStatus int
+
+const (
+	// PasswordExpiryUnknown means the directory did not supply enough
+	// information to decide. On Active Directory this is unusual; on
+	// OpenLDAP it is the normal answer when no password policy applies or
+	// none could be resolved.
+	PasswordExpiryUnknown PasswordExpiryStatus = iota
+
+	// PasswordNeverExpires means expiry is disabled for this account —
+	// the DONT_EXPIRE_PASSWORD flag on Active Directory, or a policy with
+	// pwdMaxAge of 0 under ppolicy.
+	PasswordNeverExpires
+
+	// PasswordExpires means the password has a concrete expiry moment,
+	// carried in PasswordExpiry.At. The moment may already be in the past.
+	PasswordExpires
+
+	// PasswordMustChange means the account must change its password at the
+	// next sign-in regardless of any deadline. Active Directory encodes this
+	// as pwdLastSet=0.
+	PasswordMustChange
+)
+
+// String renders the status for logs and error messages.
+func (s PasswordExpiryStatus) String() string {
+	switch s {
+	case PasswordNeverExpires:
+		return "never-expires"
+	case PasswordExpires:
+		return "expires"
+	case PasswordMustChange:
+		return "must-change"
+	case PasswordExpiryUnknown:
+		return "unknown"
+	default:
+		return "invalid"
+	}
+}
+
+// PasswordExpiry describes when a user's password expires.
+type PasswordExpiry struct {
+	// Status classifies the result. Read it before using At.
+	Status PasswordExpiryStatus
+
+	// At is the moment the password expires. It is only meaningful when
+	// Status is PasswordExpires; it is the zero time otherwise.
+	At time.Time
+}
+
+// Expired reports whether the deadline has already passed at the given time.
+// A must-change account counts as expired: it cannot be used to sign in until
+// the password is replaced.
+func (e PasswordExpiry) Expired(now time.Time) bool {
+	switch e.Status {
+	case PasswordMustChange:
+		return true
+	case PasswordExpires:
+		return !e.At.After(now)
+	case PasswordExpiryUnknown, PasswordNeverExpires:
+		return false
+	default:
+		return false
+	}
+}
+
+// ExpiringUser pairs a user with their resolved password expiry.
+type ExpiringUser struct {
+	User   *User
+	Expiry PasswordExpiry
+}
+
+// policyCache memoises pwdMaxAge per policy DN so that scanning a directory
+// costs one lookup per distinct policy rather than one per user.
+type policyCache struct {
+	mu     sync.Mutex
+	maxAge map[string]time.Duration
+}
+
+func newPolicyCache() *policyCache {
+	return &policyCache{maxAge: make(map[string]time.Duration)}
+}
+
+// PasswordExpiryFor reports when the given user's password expires.
+//
+// Active Directory answers from the entry alone: the constructed attribute
+// msDS-UserPasswordExpiryTimeComputed already folds in the domain policy and
+// any Password Settings Object, so no privileged read of the Password
+// Settings Container is required.
+//
+// OpenLDAP needs the ppolicy overlay: expiry is pwdChangedTime plus the
+// pwdMaxAge of the governing policy. The policy is taken from the entry's
+// pwdPolicySubentry, falling back to Config.PasswordPolicyDN. Without either,
+// the result is PasswordExpiryUnknown rather than a guess.
+func (l *LDAP) PasswordExpiryFor(ctx context.Context, user *User) (PasswordExpiry, error) {
+	if user == nil {
+		return PasswordExpiry{}, fmt.Errorf("password expiry: %w", ErrUserNotFound)
+	}
+
+	if l.config.IsActiveDirectory {
+		return activeDirectoryExpiry(user), nil
+	}
+
+	return l.ppolicyExpiry(ctx, user)
+}
+
+// activeDirectoryExpiry derives the result from attributes already on the
+// entry.
+func activeDirectoryExpiry(user *User) PasswordExpiry {
+	if user.MustChangePassword {
+		return PasswordExpiry{Status: PasswordMustChange}
+	}
+
+	switch user.PasswordExpiresAt {
+	case 0:
+		return PasswordExpiry{Status: PasswordExpiryUnknown}
+	case -1:
+		return PasswordExpiry{Status: PasswordNeverExpires}
+	default:
+		return PasswordExpiry{
+			Status: PasswordExpires,
+			At:     time.Unix(user.PasswordExpiresAt, 0).UTC(),
+		}
+	}
+}
+
+// ppolicyExpiry resolves expiry from pwdChangedTime and the governing policy.
+func (l *LDAP) ppolicyExpiry(ctx context.Context, user *User) (PasswordExpiry, error) {
+	if user.PwdChangedAt == 0 {
+		// No ppolicy state on the entry: either the overlay is absent or the
+		// password predates it. Reporting "unknown" is the honest answer —
+		// treating it as expiring would mail every account in the directory.
+		return PasswordExpiry{Status: PasswordExpiryUnknown}, nil
+	}
+
+	policyDN := user.PasswordPolicyDN
+	if policyDN == "" {
+		policyDN = l.config.PasswordPolicyDN
+	}
+	if policyDN == "" {
+		return PasswordExpiry{Status: PasswordExpiryUnknown}, nil
+	}
+
+	maxAge, err := l.passwordMaxAge(ctx, policyDN)
+	if err != nil {
+		return PasswordExpiry{}, err
+	}
+	if maxAge <= 0 {
+		// pwdMaxAge absent or 0 means passwords under this policy do not age out.
+		return PasswordExpiry{Status: PasswordNeverExpires}, nil
+	}
+
+	return PasswordExpiry{
+		Status: PasswordExpires,
+		At:     time.Unix(user.PwdChangedAt, 0).UTC().Add(maxAge),
+	}, nil
+}
+
+// passwordMaxAge reads pwdMaxAge from a ppolicy entry, caching the result.
+func (l *LDAP) passwordMaxAge(ctx context.Context, policyDN string) (time.Duration, error) {
+	if cached, ok := l.policies.get(policyDN); ok {
+		return cached, nil
+	}
+
+	conn, err := l.GetConnectionContext(ctx)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = conn.Close() }()
+
+	req := ldap.NewSearchRequest(
+		policyDN,
+		ldap.ScopeBaseObject, ldap.NeverDerefAliases, 1, 0, false,
+		"(objectClass=*)",
+		[]string{"pwdMaxAge"},
+		nil,
+	)
+
+	res, err := conn.Search(req)
+	if err != nil {
+		// A base-scoped search on a DN that does not exist fails with "No Such
+		// Object" rather than returning an empty result set, so translate that
+		// one code into the sentinel; anything else is a real transport or
+		// server error and is wrapped as-is.
+		if ldap.IsErrorWithCode(err, ldap.LDAPResultNoSuchObject) {
+			return 0, fmt.Errorf("read password policy %q: %w", policyDN, ErrPasswordPolicyNotFound)
+		}
+
+		return 0, fmt.Errorf("read password policy %q: %w", policyDN, err)
+	}
+
+	// A base-scoped search either errors (handled above) or returns exactly the
+	// one entry, so res.Entries[0] is safe without a length guard.
+	maxAge := parsePwdMaxAge(res.Entries[0].GetAttributeValue("pwdMaxAge"))
+	l.policies.put(policyDN, maxAge)
+
+	return maxAge, nil
+}
+
+// parsePwdMaxAge converts the ppolicy pwdMaxAge attribute, expressed in
+// seconds, into a duration. An absent, malformed or zero value yields 0,
+// which callers read as "passwords do not expire".
+func parsePwdMaxAge(value string) time.Duration {
+	if value == "" {
+		return 0
+	}
+
+	seconds, err := strconv.ParseInt(value, 10, 64)
+	if err != nil || seconds <= 0 {
+		return 0
+	}
+
+	return time.Duration(seconds) * time.Second
+}
+
+// get is nil-safe: a client assembled directly (as several tests do) has no
+// cache, and a lookup should simply miss rather than panic.
+func (c *policyCache) get(dn string) (time.Duration, bool) {
+	if c == nil {
+		return 0, false
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	d, ok := c.maxAge[dn]
+
+	return d, ok
+}
+
+func (c *policyCache) put(dn string, d time.Duration) {
+	if c == nil {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.maxAge[dn] = d
+}
+
+// UsersWithExpiringPasswords returns the enabled users whose password expires
+// within the given window, oldest deadline first.
+//
+// Accounts that cannot receive a warning, or for which one would be wrong, are
+// left out: disabled accounts, passwords that never expire, and entries the
+// directory reports nothing about. Accounts that must change at next sign-in
+// are included with status PasswordMustChange, since they are the ones already
+// locked out.
+//
+// The disabled filter relies on User.Enabled, which is derived from
+// userAccountControl. OpenLDAP has no such attribute, so every OpenLDAP user
+// reads as enabled: a caller that must exclude deactivated OpenLDAP accounts
+// has to do so by its own criterion (an ou, a group, a ppolicy lock) before
+// notifying.
+//
+// Already-expired accounts are included: a caller warning about expiry
+// generally also wants to know who is past the deadline. Filter on
+// Expiry.Expired if that is not wanted.
+func (l *LDAP) UsersWithExpiringPasswords(ctx context.Context, within time.Duration) ([]ExpiringUser, error) {
+	users, err := l.FindUsersContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	deadline := time.Now().UTC().Add(within)
+
+	resolve := func(u *User) (PasswordExpiry, error) { return l.PasswordExpiryFor(ctx, u) }
+
+	return collectExpiring(users, deadline, resolve)
+}
+
+// collectExpiring is the loop half of UsersWithExpiringPasswords, split from
+// the enumeration so the disabled-skip and error-propagation paths are
+// testable with a fake resolver instead of a faulting directory. resolve is
+// called only for enabled users, in order.
+func collectExpiring(
+	users []User,
+	deadline time.Time,
+	resolve func(*User) (PasswordExpiry, error),
+) ([]ExpiringUser, error) {
+	expiring := make([]ExpiringUser, 0, len(users))
+
+	for i := range users {
+		user := &users[i]
+		if !user.Enabled {
+			continue
+		}
+
+		expiry, err := resolve(user)
+		if err != nil {
+			return nil, err
+		}
+
+		if entry, ok := classifyExpiring(user, expiry, deadline); ok {
+			expiring = append(expiring, entry)
+		}
+	}
+
+	sortExpiringUsers(expiring)
+
+	return expiring, nil
+}
+
+// classifyExpiring decides whether a resolved expiry belongs in the
+// within-window result, and returns the entry to add when it does. It is the
+// pure half of UsersWithExpiringPasswords, split out so every inclusion rule
+// is testable without a directory.
+//
+// A must-change account is always included: it is already blocked, so the
+// deadline is irrelevant. An expiring account is included only when its
+// deadline falls on or before the window's edge. Unknown and never-expires are
+// never included — acting on them is what would mail an entire directory.
+func classifyExpiring(user *User, expiry PasswordExpiry, deadline time.Time) (ExpiringUser, bool) {
+	switch expiry.Status {
+	case PasswordMustChange:
+		return ExpiringUser{User: user, Expiry: expiry}, true
+	case PasswordExpires:
+		if !expiry.At.After(deadline) {
+			return ExpiringUser{User: user, Expiry: expiry}, true
+		}
+
+		return ExpiringUser{}, false
+	case PasswordExpiryUnknown, PasswordNeverExpires:
+		return ExpiringUser{}, false
+	default:
+		return ExpiringUser{}, false
+	}
+}
+
+// sortExpiringUsers orders by deadline, must-change first since those accounts
+// are already blocked.
+func sortExpiringUsers(users []ExpiringUser) {
+	slices.SortFunc(users, func(a, b ExpiringUser) int {
+		if a.Expiry.Status != b.Expiry.Status {
+			if a.Expiry.Status == PasswordMustChange {
+				return -1
+			}
+			if b.Expiry.Status == PasswordMustChange {
+				return 1
+			}
+		}
+
+		return a.Expiry.At.Compare(b.Expiry.At)
+	})
+}

--- a/password_expiry_integration_test.go
+++ b/password_expiry_integration_test.go
@@ -1,0 +1,259 @@
+//go:build integration
+// +build integration
+
+package ldap
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/go-ldap/ldap/v3"
+	"github.com/stretchr/testify/require"
+)
+
+// ppolicyMaxAge is deliberately short in wall-clock terms but long enough that
+// the computed deadline is unambiguously in the future.
+const ppolicyMaxAge = 90 * 24 * time.Hour
+
+// enablePpolicy loads the ppolicy overlay and installs a default policy.
+//
+// The overlay is what produces pwdChangedTime; without it OpenLDAP records
+// nothing about password age and PasswordExpiryFor can only answer "unknown".
+// osixia/openldap ships the module but does not enable the overlay.
+func enablePpolicy(t *testing.T, tc *TestContainer, policyDN string) {
+	t.Helper()
+
+	cfgConn, err := ldap.DialURL(tc.Config.Server)
+	require.NoError(t, err, "dial for cn=config")
+	defer func() { _ = cfgConn.Close() }()
+	require.NoError(t, cfgConn.Bind("cn=admin,cn=config", "config123"), "bind cn=config")
+
+	// The module may already be loaded; only the overlay is guaranteed absent.
+	modAdd := ldap.NewModifyRequest("cn=module{0},cn=config", nil)
+	modAdd.Add("olcModuleLoad", []string{"ppolicy.la"})
+	if err := cfgConn.Modify(modAdd); err != nil {
+		t.Logf("loading ppolicy module reported %v (already loaded is fine)", err)
+	}
+
+	overlay := ldap.NewAddRequest("olcOverlay=ppolicy,olcDatabase={1}mdb,cn=config", nil)
+	overlay.Attribute("objectClass", []string{"olcOverlayConfig", "olcPPolicyConfig"})
+	overlay.Attribute("olcOverlay", []string{"ppolicy"})
+	overlay.Attribute("olcPPolicyDefault", []string{policyDN})
+	overlay.Attribute("olcPPolicyHashCleartext", []string{"TRUE"})
+	if err := cfgConn.Add(overlay); err != nil {
+		require.True(t, ldap.IsErrorWithCode(err, ldap.LDAPResultEntryAlreadyExists),
+			"enable ppolicy overlay: %v", err)
+	}
+}
+
+// createPasswordPolicy adds the policy entry the overlay points at.
+func createPasswordPolicy(t *testing.T, conn *ldap.Conn, policyDN string, maxAge time.Duration) {
+	t.Helper()
+
+	add := ldap.NewAddRequest(policyDN, nil)
+	add.Attribute("objectClass", []string{"top", "device", "pwdPolicy"})
+	add.Attribute("cn", []string{"default"})
+	// pwdAttribute is defined with OID syntax, so the numeric OID of
+	// userPassword is required — the attribute *name* is rejected as
+	// "invalid per syntax" by OpenLDAP.
+	add.Attribute("pwdAttribute", []string{"2.5.4.35"})
+	add.Attribute("pwdMaxAge", []string{fmt.Sprintf("%d", int64(maxAge.Seconds()))})
+	if err := conn.Add(add); err != nil {
+		require.True(t, ldap.IsErrorWithCode(err, ldap.LDAPResultEntryAlreadyExists),
+			"create password policy: %v", err)
+	}
+}
+
+// changePasswordAsUser performs the change through the user's own bind.
+//
+// This matters: the ppolicy overlay does not maintain policy state for writes
+// made by the rootdn, so an administrative Modify leaves pwdChangedTime unset
+// and the whole feature looks broken. Doing it as the user is both what
+// records the timestamp and what a self-service tool actually does.
+func changePasswordAsUser(t *testing.T, tc *TestContainer, userDN, oldPassword, newPassword string) {
+	t.Helper()
+
+	conn, err := ldap.DialURL(tc.Config.Server)
+	require.NoError(t, err, "dial as user")
+	defer func() { _ = conn.Close() }()
+	require.NoError(t, conn.Bind(userDN, oldPassword), "bind as the user")
+
+	req := ldap.NewPasswordModifyRequest(userDN, oldPassword, newPassword)
+	_, err = conn.PasswordModify(req)
+	require.NoError(t, err, "password modify as the user")
+}
+
+// ppolicyFixture is the setup every ppolicy test shares: a container with the
+// overlay enabled, a default policy of the given max age, and the seeded valid
+// user's password freshly changed (which is what records pwdChangedTime). It
+// returns the client — with PasswordPolicyDN pointed at the policy — the
+// policy DN, and the test data.
+func ppolicyFixture(t *testing.T, tc *TestContainer, maxAge time.Duration) (*LDAP, string, *TestData) {
+	t.Helper()
+
+	policyDN := fmt.Sprintf("cn=default,%s", tc.BaseDN)
+
+	adminConn, err := ldap.DialURL(tc.Config.Server)
+	require.NoError(t, err, "dial")
+	defer func() { _ = adminConn.Close() }()
+	require.NoError(t, adminConn.Bind(tc.AdminUser, tc.AdminPass), "bind admin")
+
+	createPasswordPolicy(t, adminConn, policyDN, maxAge)
+	enablePpolicy(t, tc, policyDN)
+
+	data := tc.GetTestData()
+	changePasswordAsUser(t, tc, data.ValidUserDN, data.ValidUserPassword, "FreshPassword123!")
+
+	client := tc.GetLDAPClient(t)
+	client.config.PasswordPolicyDN = policyDN
+
+	return client, policyDN, data
+}
+
+// TestIntegrationPasswordExpiry_OpenLDAPPpolicy proves the OpenLDAP path end to
+// end: the overlay records pwdChangedTime when a password is set, the library
+// reads that operational attribute, resolves pwdMaxAge from the policy, and
+// derives a deadline. None of that is observable without a real server — the
+// attributes are operational and server-generated.
+func TestIntegrationPasswordExpiry_OpenLDAPPpolicy(t *testing.T) {
+	tc := SetupTestContainer(t)
+	defer tc.Close(t)
+
+	before := time.Now().UTC().Add(-time.Minute)
+	client, _, data := ppolicyFixture(t, tc, ppolicyMaxAge)
+
+	user, err := client.FindUserByDNContext(t.Context(), data.ValidUserDN)
+	require.NoError(t, err, "find user")
+
+	require.NotZero(t, user.PwdChangedAt,
+		"pwdChangedTime must be read back; it is operational and excluded from a default search")
+	require.GreaterOrEqual(t, user.PwdChangedAt, before.Unix(), "pwdChangedTime should be the write we just made")
+
+	expiry, err := client.PasswordExpiryFor(t.Context(), user)
+	require.NoError(t, err, "resolve expiry")
+
+	require.Equal(t, PasswordExpires, expiry.Status, "a policy with pwdMaxAge must yield a deadline")
+	require.False(t, expiry.Expired(time.Now()), "a password just set must not be expired")
+
+	want := time.Unix(user.PwdChangedAt, 0).UTC().Add(ppolicyMaxAge)
+	require.WithinDuration(t, want, expiry.At, time.Second, "deadline is pwdChangedTime + pwdMaxAge")
+}
+
+// A policy of pwdMaxAge 0 disables ageing. Verified against the server rather
+// than only in a unit test, because it is the configuration an operator lands
+// on when they want the overlay's lockout features but no expiry.
+func TestIntegrationPasswordExpiry_ZeroMaxAgeNeverExpires(t *testing.T) {
+	tc := SetupTestContainer(t)
+	defer tc.Close(t)
+
+	client, _, data := ppolicyFixture(t, tc, 0)
+
+	user, err := client.FindUserByDNContext(t.Context(), data.ValidUserDN)
+	require.NoError(t, err, "find user")
+
+	expiry, err := client.PasswordExpiryFor(t.Context(), user)
+	require.NoError(t, err, "resolve expiry")
+	require.Equal(t, PasswordNeverExpires, expiry.Status)
+	require.False(t, expiry.Expired(time.Now()))
+}
+
+// Without the overlay there is no pwdChangedTime, and the honest answer is
+// "unknown" — not "expiring". A notifier acting on a wrong answer here would
+// mail the entire directory.
+func TestIntegrationPasswordExpiry_UnknownWithoutPpolicy(t *testing.T) {
+	tc := SetupTestContainer(t)
+	defer tc.Close(t)
+
+	client := tc.GetLDAPClient(t)
+	data := tc.GetTestData()
+
+	user, err := client.FindUserByDNContext(t.Context(), data.ValidUserDN)
+	require.NoError(t, err, "find user")
+
+	expiry, err := client.PasswordExpiryFor(t.Context(), user)
+	require.NoError(t, err, "resolve expiry")
+	require.Equal(t, PasswordExpiryUnknown, expiry.Status,
+		"a directory without ppolicy reports nothing about password age")
+	require.False(t, expiry.Expired(time.Now()), "unknown must never read as expired")
+}
+
+// UsersWithExpiringPasswords is the API a notifier would drive, so it is worth
+// exercising against a real directory rather than trusting the pieces.
+//
+// The seeded users get their passwords before the overlay is enabled, so they
+// carry no pwdChangedTime and must be reported as unknown — which makes them a
+// built-in negative case: only the account whose password is changed
+// afterwards may appear.
+func TestIntegrationUsersWithExpiringPasswords(t *testing.T) {
+	tc := SetupTestContainer(t)
+	defer tc.Close(t)
+
+	client, _, data := ppolicyFixture(t, tc, ppolicyMaxAge)
+
+	// A window comfortably beyond the policy age: the changed account is due.
+	due, err := client.UsersWithExpiringPasswords(t.Context(), ppolicyMaxAge+24*time.Hour)
+	require.NoError(t, err, "scan for expiring passwords")
+
+	var found *ExpiringUser
+	for i := range due {
+		if due[i].User.DN() == data.ValidUserDN {
+			found = &due[i]
+		}
+	}
+	require.NotNil(t, found, "the account whose password was changed should be due within the window")
+	require.Equal(t, PasswordExpires, found.Expiry.Status)
+	require.False(t, found.Expiry.Expired(time.Now()), "a password just set is not expired")
+
+	// Accounts the directory says nothing about must never be swept in — that
+	// is the difference between warning the right people and mailing everyone.
+	for _, u := range due {
+		require.NotEqual(t, PasswordExpiryUnknown, u.Expiry.Status,
+			"unknown-expiry accounts must be excluded, got %s", u.User.DN())
+	}
+
+	// A window shorter than the remaining lifetime must exclude it again.
+	none, err := client.UsersWithExpiringPasswords(t.Context(), time.Hour)
+	require.NoError(t, err, "scan with a short window")
+	for _, u := range none {
+		require.NotEqual(t, data.ValidUserDN, u.User.DN(),
+			"a password with ~90 days left must not appear in a one-hour window")
+	}
+}
+
+// A policy DN that does not resolve must surface as an error, not be swallowed
+// into "unknown" — a misconfigured PasswordPolicyDN should be loud.
+func TestIntegrationPasswordExpiry_MissingPolicyDNErrors(t *testing.T) {
+	tc := SetupTestContainer(t)
+	defer tc.Close(t)
+
+	client, _, data := ppolicyFixture(t, tc, ppolicyMaxAge)
+	// Point the client-wide default at a policy entry that does not exist.
+	client.config.PasswordPolicyDN = fmt.Sprintf("cn=ghost,%s", tc.BaseDN)
+
+	user, err := client.FindUserByDNContext(t.Context(), data.ValidUserDN)
+	require.NoError(t, err, "find user")
+
+	_, err = client.PasswordExpiryFor(t.Context(), user)
+	require.Error(t, err, "an unresolvable policy DN must be reported")
+	require.ErrorIs(t, err, ErrPasswordPolicyNotFound)
+}
+
+// A policy DN that is syntactically invalid fails the search with code 34
+// (Invalid DN Syntax) rather than 32, so it exercises the general wrapped-error
+// path rather than the ErrPasswordPolicyNotFound translation.
+func TestIntegrationPasswordExpiry_MalformedPolicyDNPropagatesError(t *testing.T) {
+	tc := SetupTestContainer(t)
+	defer tc.Close(t)
+
+	client, _, data := ppolicyFixture(t, tc, ppolicyMaxAge)
+	client.config.PasswordPolicyDN = "this is not a dn"
+
+	user, err := client.FindUserByDNContext(t.Context(), data.ValidUserDN)
+	require.NoError(t, err, "find user")
+
+	_, err = client.PasswordExpiryFor(t.Context(), user)
+	require.Error(t, err, "a malformed policy DN must surface as an error")
+	// It is a real LDAP error, not the not-found sentinel.
+	require.NotErrorIs(t, err, ErrPasswordPolicyNotFound)
+}

--- a/password_expiry_test.go
+++ b/password_expiry_test.go
@@ -1,0 +1,505 @@
+package ldap
+
+import (
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+)
+
+func TestPasswordExpiryStatus_String(t *testing.T) {
+	tests := []struct {
+		status PasswordExpiryStatus
+		want   string
+	}{
+		{PasswordExpiryUnknown, "unknown"},
+		{PasswordNeverExpires, "never-expires"},
+		{PasswordExpires, "expires"},
+		{PasswordMustChange, "must-change"},
+		{PasswordExpiryStatus(99), "invalid"},
+	}
+
+	for _, tt := range tests {
+		if got := tt.status.String(); got != tt.want {
+			t.Errorf("PasswordExpiryStatus(%d).String() = %q, want %q", tt.status, got, tt.want)
+		}
+	}
+}
+
+func TestPasswordExpiry_Expired(t *testing.T) {
+	now := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name string
+		in   PasswordExpiry
+		want bool
+	}{
+		{
+			name: "deadline in the future",
+			in:   PasswordExpiry{Status: PasswordExpires, At: now.Add(time.Hour)},
+			want: false,
+		},
+		{
+			name: "deadline in the past",
+			in:   PasswordExpiry{Status: PasswordExpires, At: now.Add(-time.Hour)},
+			want: true,
+		},
+		{
+			// The deadline is the moment access stops, so reaching it exactly
+			// counts as expired rather than as the last usable instant.
+			name: "deadline exactly now",
+			in:   PasswordExpiry{Status: PasswordExpires, At: now},
+			want: true,
+		},
+		{
+			name: "must change at next sign-in",
+			in:   PasswordExpiry{Status: PasswordMustChange},
+			want: true,
+		},
+		{
+			name: "never expires",
+			in:   PasswordExpiry{Status: PasswordNeverExpires},
+			want: false,
+		},
+		{
+			// Unknown must never be reported as expired: a caller acting on it
+			// would lock out or mail every account the directory is quiet about.
+			name: "unknown",
+			in:   PasswordExpiry{Status: PasswordExpiryUnknown},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.in.Expired(now); got != tt.want {
+				t.Errorf("Expired() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestActiveDirectoryExpiry(t *testing.T) {
+	const expiryUnix = int64(1785600000)
+
+	tests := []struct {
+		name       string
+		user       User
+		wantStatus PasswordExpiryStatus
+		wantAt     time.Time
+	}{
+		{
+			// pwdLastSet=0 outranks any deadline: the account cannot sign in
+			// until the password is replaced.
+			name:       "must change wins over a concrete deadline",
+			user:       User{MustChangePassword: true, PasswordExpiresAt: expiryUnix},
+			wantStatus: PasswordMustChange,
+		},
+		{
+			name:       "never expires sentinel",
+			user:       User{PasswordExpiresAt: -1},
+			wantStatus: PasswordNeverExpires,
+		},
+		{
+			name:       "attribute absent",
+			user:       User{},
+			wantStatus: PasswordExpiryUnknown,
+		},
+		{
+			name:       "concrete deadline",
+			user:       User{PasswordExpiresAt: expiryUnix},
+			wantStatus: PasswordExpires,
+			wantAt:     time.Unix(expiryUnix, 0).UTC(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := activeDirectoryExpiry(&tt.user)
+
+			if got.Status != tt.wantStatus {
+				t.Errorf("Status = %v, want %v", got.Status, tt.wantStatus)
+			}
+			if !tt.wantAt.IsZero() && !got.At.Equal(tt.wantAt) {
+				t.Errorf("At = %v, want %v", got.At, tt.wantAt)
+			}
+		})
+	}
+}
+
+func TestParsePwdMaxAge(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  time.Duration
+	}{
+		{"absent", "", 0},
+		{"zero means no ageing", "0", 0},
+		{"negative is nonsense", "-1", 0},
+		{"not a number", "ninety days", 0},
+		{"ninety days in seconds", "7776000", 90 * 24 * time.Hour},
+		{"one hour", "3600", time.Hour},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parsePwdMaxAge(tt.value); got != tt.want {
+				t.Errorf("parsePwdMaxAge(%q) = %v, want %v", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+// Without ppolicy state or a policy DN the answer must be "unknown". Guessing
+// here would make a notifier mail an entire directory.
+func TestPpolicyExpiry_UnknownWithoutEnoughInformation(t *testing.T) {
+	tests := []struct {
+		name   string
+		user   User
+		config Config
+	}{
+		{
+			name: "no pwdChangedTime on the entry",
+			user: User{PasswordPolicyDN: "cn=default,ou=policies,dc=example,dc=com"},
+		},
+		{
+			name: "pwdChangedTime but no policy anywhere",
+			user: User{PwdChangedAt: 1750000000},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := tt.config
+			client := &LDAP{config: &cfg}
+
+			got, err := client.ppolicyExpiry(t.Context(), &tt.user)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.Status != PasswordExpiryUnknown {
+				t.Errorf("Status = %v, want %v", got.Status, PasswordExpiryUnknown)
+			}
+		})
+	}
+}
+
+// A cached policy is enough to answer, so no connection is attempted — which
+// is what makes this testable without a server, and what keeps a directory
+// scan from issuing one policy read per user.
+func TestPpolicyExpiry_UsesTheCachedPolicy(t *testing.T) {
+	const policyDN = "cn=default,ou=policies,dc=example,dc=com"
+
+	changed := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	cfg := Config{}
+	client := &LDAP{config: &cfg, policies: newPolicyCache()}
+	client.policies.put(policyDN, 90*24*time.Hour)
+
+	user := User{PwdChangedAt: changed.Unix(), PasswordPolicyDN: policyDN}
+
+	got, err := client.ppolicyExpiry(t.Context(), &user)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Status != PasswordExpires {
+		t.Fatalf("Status = %v, want %v", got.Status, PasswordExpires)
+	}
+	if want := changed.Add(90 * 24 * time.Hour); !got.At.Equal(want) {
+		t.Errorf("At = %v, want %v", got.At, want)
+	}
+}
+
+// A policy with pwdMaxAge 0 disables ageing; it must not be reported as an
+// immediate expiry.
+func TestPpolicyExpiry_ZeroMaxAgeNeverExpires(t *testing.T) {
+	const policyDN = "cn=nolapse,ou=policies,dc=example,dc=com"
+
+	cfg := Config{PasswordPolicyDN: policyDN}
+	client := &LDAP{config: &cfg, policies: newPolicyCache()}
+	client.policies.put(policyDN, 0)
+
+	got, err := client.ppolicyExpiry(t.Context(), &User{PwdChangedAt: 1750000000})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Status != PasswordNeverExpires {
+		t.Errorf("Status = %v, want %v", got.Status, PasswordNeverExpires)
+	}
+}
+
+// The per-user pwdPolicySubentry must win over the client-wide default.
+func TestPpolicyExpiry_EntryPolicyOverridesTheDefault(t *testing.T) {
+	const (
+		defaultDN = "cn=default,ou=policies,dc=example,dc=com"
+		strictDN  = "cn=strict,ou=policies,dc=example,dc=com"
+	)
+
+	changed := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	cfg := Config{PasswordPolicyDN: defaultDN}
+	client := &LDAP{config: &cfg, policies: newPolicyCache()}
+	client.policies.put(defaultDN, 365*24*time.Hour)
+	client.policies.put(strictDN, 30*24*time.Hour)
+
+	user := User{PwdChangedAt: changed.Unix(), PasswordPolicyDN: strictDN}
+
+	got, err := client.ppolicyExpiry(t.Context(), &user)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if want := changed.Add(30 * 24 * time.Hour); !got.At.Equal(want) {
+		t.Errorf("At = %v, want %v — the entry's own policy should win", got.At, want)
+	}
+}
+
+func TestPasswordExpiryFor_NilUser(t *testing.T) {
+	cfg := Config{}
+	client := &LDAP{config: &cfg}
+
+	if _, err := client.PasswordExpiryFor(t.Context(), nil); err == nil {
+		t.Fatal("expected an error for a nil user")
+	}
+}
+
+// A client assembled without the constructor has no cache; lookups must miss
+// rather than panic.
+func TestPolicyCache_NilReceiverIsSafe(t *testing.T) {
+	var c *policyCache
+
+	if _, ok := c.get("cn=whatever"); ok {
+		t.Error("a nil cache must not report a hit")
+	}
+	c.put("cn=whatever", time.Hour)
+}
+
+func TestSortExpiringUsers(t *testing.T) {
+	base := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+
+	users := []ExpiringUser{
+		{User: &User{SAMAccountName: "late"}, Expiry: PasswordExpiry{Status: PasswordExpires, At: base.Add(48 * time.Hour)}},
+		{User: &User{SAMAccountName: "blocked"}, Expiry: PasswordExpiry{Status: PasswordMustChange}},
+		{User: &User{SAMAccountName: "soon"}, Expiry: PasswordExpiry{Status: PasswordExpires, At: base.Add(time.Hour)}},
+	}
+
+	sortExpiringUsers(users)
+
+	want := []string{"blocked", "soon", "late"}
+	for i, name := range want {
+		if users[i].User.SAMAccountName != name {
+			t.Errorf("position %d = %q, want %q", i, users[i].User.SAMAccountName, name)
+		}
+	}
+}
+
+// The Active Directory branch answers from the entry alone, so it is reachable
+// without a server — unlike the ppolicy branch, which needs a policy read.
+func TestPasswordExpiryFor_ActiveDirectoryBranch(t *testing.T) {
+	const expiryUnix = int64(1785600000)
+
+	cfg := Config{IsActiveDirectory: true}
+	client := &LDAP{config: &cfg}
+
+	got, err := client.PasswordExpiryFor(t.Context(), &User{PasswordExpiresAt: expiryUnix})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Status != PasswordExpires {
+		t.Fatalf("Status = %v, want %v", got.Status, PasswordExpires)
+	}
+	if want := time.Unix(expiryUnix, 0).UTC(); !got.At.Equal(want) {
+		t.Errorf("At = %v, want %v", got.At, want)
+	}
+
+	// The ppolicy attributes must be ignored on Active Directory: pwdChangedTime
+	// is not what governs expiry there, and honouring it would produce a second,
+	// contradictory answer.
+	mixed, err := client.PasswordExpiryFor(t.Context(), &User{
+		PasswordExpiresAt: -1,
+		PwdChangedAt:      1750000000,
+		PasswordPolicyDN:  "cn=default,dc=example,dc=com",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mixed.Status != PasswordNeverExpires {
+		t.Errorf("Status = %v, want %v — ppolicy attributes must not override AD", mixed.Status, PasswordNeverExpires)
+	}
+}
+
+// An out-of-range status must never read as expired; the zero value of a future
+// enum addition would otherwise lock people out.
+func TestPasswordExpiry_ExpiredRejectsUnknownStatus(t *testing.T) {
+	e := PasswordExpiry{Status: PasswordExpiryStatus(99), At: time.Unix(0, 0)}
+	if e.Expired(time.Now()) {
+		t.Error("an unrecognised status must not be reported as expired")
+	}
+}
+
+// unreachableClient is assembled directly, without New's eager connect, so it
+// dials only when a method reaches the network — pointing at a closed port
+// then exercises the error paths a happy-path test cannot reach. It matches
+// the direct-construction pattern the auth tests use for the same purpose.
+func unreachableClient(t *testing.T) *LDAP {
+	t.Helper()
+
+	return &LDAP{
+		config:   &Config{Server: "ldap://127.0.0.1:1", BaseDN: "dc=example,dc=org"},
+		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		policies: newPolicyCache(),
+	}
+}
+
+// A policy read that cannot connect must propagate the error rather than
+// resolve to a deadline. The policy is not cached, so passwordMaxAge dials.
+func TestPpolicyExpiry_ConnectionErrorPropagates(t *testing.T) {
+	client := unreachableClient(t)
+	client.config.PasswordPolicyDN = "cn=default,dc=example,dc=org"
+
+	_, err := client.PasswordExpiryFor(t.Context(), &User{PwdChangedAt: 1750000000})
+	if err == nil {
+		t.Fatal("expected a connection error to propagate from the policy read")
+	}
+}
+
+// The directory scan must surface a failure to enumerate users rather than
+// return a partial, misleading list.
+func TestUsersWithExpiringPasswords_EnumerationErrorPropagates(t *testing.T) {
+	client := unreachableClient(t)
+
+	if _, err := client.UsersWithExpiringPasswords(t.Context(), 30*24*time.Hour); err == nil {
+		t.Fatal("expected the user enumeration error to propagate")
+	}
+}
+
+func TestClassifyExpiring(t *testing.T) {
+	deadline := time.Date(2026, 8, 22, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name   string
+		expiry PasswordExpiry
+		wantOK bool
+	}{
+		{
+			name:   "must change is always included",
+			expiry: PasswordExpiry{Status: PasswordMustChange},
+			wantOK: true,
+		},
+		{
+			name:   "expires within the window",
+			expiry: PasswordExpiry{Status: PasswordExpires, At: deadline.Add(-time.Hour)},
+			wantOK: true,
+		},
+		{
+			name:   "expires exactly on the window edge",
+			expiry: PasswordExpiry{Status: PasswordExpires, At: deadline},
+			wantOK: true,
+		},
+		{
+			name:   "expires after the window",
+			expiry: PasswordExpiry{Status: PasswordExpires, At: deadline.Add(time.Hour)},
+			wantOK: false,
+		},
+		{
+			name:   "unknown is excluded",
+			expiry: PasswordExpiry{Status: PasswordExpiryUnknown},
+			wantOK: false,
+		},
+		{
+			name:   "never expires is excluded",
+			expiry: PasswordExpiry{Status: PasswordNeverExpires},
+			wantOK: false,
+		},
+		{
+			name:   "unrecognised status is excluded",
+			expiry: PasswordExpiry{Status: PasswordExpiryStatus(99)},
+			wantOK: false,
+		},
+	}
+
+	user := &User{SAMAccountName: "sample"}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entry, ok := classifyExpiring(user, tt.expiry, deadline)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if ok && entry.User != user {
+				t.Error("an included entry should carry the user it was built from")
+			}
+		})
+	}
+}
+
+func TestCollectExpiring(t *testing.T) {
+	deadline := time.Date(2026, 8, 22, 12, 0, 0, 0, time.UTC)
+
+	resolve := func(u *User) (PasswordExpiry, error) {
+		// The name encodes the expiry so the fake needs no state.
+		switch u.SAMAccountName {
+		case "soon":
+			return PasswordExpiry{Status: PasswordExpires, At: deadline.Add(-time.Hour)}, nil
+		case "later":
+			return PasswordExpiry{Status: PasswordExpires, At: deadline.Add(time.Hour)}, nil
+		case "blocked":
+			return PasswordExpiry{Status: PasswordMustChange}, nil
+		default:
+			return PasswordExpiry{Status: PasswordExpiryUnknown}, nil
+		}
+	}
+
+	users := []User{
+		{SAMAccountName: "soon", Enabled: true},
+		{SAMAccountName: "later", Enabled: true},
+		{SAMAccountName: "blocked", Enabled: true},
+		// Disabled but soon-to-expire: it must be skipped before the resolver
+		// is even asked.
+		{SAMAccountName: "soon", Enabled: false},
+	}
+
+	got, err := collectExpiring(users, deadline, resolve)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// blocked (must-change, sorts first) then soon; later is outside the window,
+	// the disabled one is skipped.
+	want := []string{"blocked", "soon"}
+	if len(got) != len(want) {
+		t.Fatalf("got %d entries, want %d: %+v", len(got), len(want), got)
+	}
+	for i, name := range want {
+		if got[i].User.SAMAccountName != name {
+			t.Errorf("position %d = %q, want %q", i, got[i].User.SAMAccountName, name)
+		}
+	}
+}
+
+// An error from the resolver aborts the scan rather than yielding a partial
+// list a caller might act on as if complete.
+func TestCollectExpiring_ResolverErrorPropagates(t *testing.T) {
+	sentinel := errors.New("resolver failed")
+	resolve := func(*User) (PasswordExpiry, error) { return PasswordExpiry{}, sentinel }
+
+	_, err := collectExpiring([]User{{SAMAccountName: "x", Enabled: true}}, time.Now(), resolve)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("err = %v, want it to wrap the resolver error", err)
+	}
+}
+
+// A disabled user must be skipped before the resolver runs — the resolver here
+// fails the test if it is ever called.
+func TestCollectExpiring_DisabledUserSkipsTheResolver(t *testing.T) {
+	resolve := func(*User) (PasswordExpiry, error) {
+		t.Fatal("resolver must not be called for a disabled user")
+
+		return PasswordExpiry{}, nil
+	}
+
+	got, err := collectExpiring([]User{{SAMAccountName: "off", Enabled: false}}, time.Now(), resolve)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("got %d entries, want none", len(got))
+	}
+}

--- a/users.go
+++ b/users.go
@@ -39,6 +39,13 @@ var (
 		"manager", "telephoneNumber", "mobile", "physicalDeliveryOfficeName",
 		// Security posture
 		"accountExpires", "pwdLastSet", "lockoutTime",
+		// Password expiry. msDS-UserPasswordExpiryTimeComputed is an Active
+		// Directory *constructed* attribute — the server folds the domain
+		// policy and any Password Settings Object into it, so it is only
+		// returned when named explicitly. pwdChangedTime and pwdPolicySubentry
+		// are the OpenLDAP ppolicy counterparts and are *operational*, which
+		// likewise excludes them from a default search.
+		"msDS-UserPasswordExpiryTimeComputed", "pwdChangedTime", "pwdPolicySubentry",
 		// Privileged-account marker — AD sets adminCount=1 on users who are
 		// (or were) members of a protected group (Domain Admins, Enterprise
 		// Admins, Administrators, …). Used by clients to tag privileged
@@ -88,6 +95,21 @@ type User struct {
 	//   -1 — never expires (AD's sentinel 9223372036854775807 = 0x7FFFFFFFFFFFFFFF)
 	//   >0 — concrete expiry timestamp in Unix seconds.
 	AccountExpires int64
+	// PasswordExpiresAt is the Unix-seconds timestamp at which the current
+	// password expires, as reported by Active Directory's constructed
+	// msDS-UserPasswordExpiryTimeComputed attribute.
+	//   0  — not reported (always the case on non-AD directories)
+	//   -1 — never expires
+	//   >0 — concrete expiry timestamp in Unix seconds.
+	// Use LDAP.PasswordExpiryFor for a directory-independent answer.
+	PasswordExpiresAt int64
+	// PwdChangedAt is the Unix-seconds timestamp from the OpenLDAP ppolicy
+	// operational attribute pwdChangedTime, or 0 when the overlay is not in
+	// use. Expiry is this plus the governing policy's pwdMaxAge.
+	PwdChangedAt int64
+	// PasswordPolicyDN is the ppolicy subentry governing this user, from
+	// pwdPolicySubentry. Empty means the directory's default policy applies.
+	PasswordPolicyDN string
 	// PwdLastSet is the Unix-seconds timestamp at which the user last changed
 	// their password, 0 when unset. When the AD value is 0 it means the user
 	// must change password at next logon; callers should consult MustChangePassword.
@@ -168,6 +190,9 @@ func userFromEntry(entry *ldap.Entry) (*User, error) {
 		Mobile:             entry.GetAttributeValue("mobile"),
 		Office:             entry.GetAttributeValue("physicalDeliveryOfficeName"),
 		AccountExpires:     parseAccountExpires(entry.GetAttributeValue("accountExpires")),
+		PasswordExpiresAt:  parseAccountExpires(entry.GetAttributeValue("msDS-UserPasswordExpiryTimeComputed")),
+		PwdChangedAt:       parseGeneralizedTime(entry.GetAttributeValue("pwdChangedTime")),
+		PasswordPolicyDN:   entry.GetAttributeValue("pwdPolicySubentry"),
 		PwdLastSet:         pwdLastSet,
 		MustChangePassword: mustChange,
 		LockoutTime:        parseFileTimeSeconds(entry.GetAttributeValue("lockoutTime")),
@@ -290,9 +315,15 @@ func (l *LDAP) FindUserByDNContext(ctx context.Context, dn string) (user *User, 
 
 	// Use generic DN search function to eliminate code duplication
 	params := dnSearchParams{
-		operation:   "FindUserByDN",
-		filter:      "(|(objectClass=user)(objectClass=inetOrgPerson)(objectClass=person))",
-		attributes:  []string{"memberOf", "cn", "sAMAccountName", "uid", "userAccountControl", "description", "mail"},
+		operation: "FindUserByDN",
+		filter:    "(|(objectClass=user)(objectClass=inetOrgPerson)(objectClass=person))",
+		// Same attribute list as every other user search. It used to be a
+		// shorter hand-written set, which silently returned a User with the
+		// security-posture and audit fields zeroed — pwdLastSet,
+		// accountExpires, lockoutTime, whenCreated and now the password-expiry
+		// attributes — so the same type meant different things depending on
+		// which finder produced it.
+		attributes:  userFields,
 		notFoundErr: ErrUserNotFound,
 		logPrefix:   "user_",
 	}


### PR DESCRIPTION
Groundwork for password-expiry reminders (netresearch/ldap-selfservice-password-changer#628). This PR is the directory half only — no scheduling, no mail.

## API

```go
expiry, err := client.PasswordExpiryFor(ctx, user)
soon,   err := client.UsersWithExpiringPasswords(ctx, 30*24*time.Hour)
```

`PasswordExpiry` distinguishes **four** states rather than returning a bare timestamp:

| Status | Meaning |
| --- | --- |
| `expires` | concrete deadline in `At` (may be in the past) |
| `never-expires` | DONT_EXPIRE_PASSWORD, or `pwdMaxAge` 0 |
| `must-change` | AD `pwdLastSet=0` — blocked until changed |
| `unknown` | the directory said nothing usable |

The distinction is the point. A consumer that collapses `unknown` into "expiring" would act on every account the directory happens to be quiet about — for the notifier this feature exists for, that means mailing the entire company.

## How each backend is resolved

**Active Directory** — `msDS-UserPasswordExpiryTimeComputed`. It is *constructed*, so the server folds in the domain policy **and** any Password Settings Object. That avoids reading the Password Settings Container, which is Domain-Admins-only by default; the `pwdLastSet` + `maxPwdAge` + PSO route would need privileges the existing read-only service account does not have. Being constructed, it is only returned when named explicitly — hence the addition to `userFields`.

**OpenLDAP** — ppolicy's operational `pwdChangedTime` plus the governing policy's `pwdMaxAge`, taken from the entry's `pwdPolicySubentry` and falling back to the new `Config.PasswordPolicyDN`. `pwdMaxAge` is memoised per policy DN, so a directory scan costs one policy read per distinct policy rather than one per user.

## A pre-existing bug this surfaced

`FindUserByDNContext` requested its **own short attribute list** instead of the shared `userFields`, so it silently returned a `User` with `pwdLastSet`, `accountExpires`, `lockoutTime` and `whenCreated` zeroed — the same type meaning different things depending on which finder produced it. Now fixed to use `userFields`.

This is what the integration test earned its keep for: the server demonstrably wrote `pwdChangedTime`, yet the library read back nothing. Two of my own hypotheses were wrong on the way — that the rootdn bypasses ppolicy state, and that operational attributes cannot be requested by name. Both were disproved against a live server before the real cause was found.

## Verification

Integration tests enable the ppolicy overlay on the test container and exercise the chain end to end:

| Test | Asserts |
| --- | --- |
| `..._OpenLDAPPpolicy` | deadline equals `pwdChangedTime + pwdMaxAge` |
| `..._ZeroMaxAgeNeverExpires` | `pwdMaxAge` 0 reports never-expires, not an instant expiry |
| `..._UnknownWithoutPpolicy` | no overlay reports unknown, never expiring |

Two details recorded in the test code because they cost time to discover and are not in the docs: `pwdAttribute` requires the numeric OID `2.5.4.35` and rejects the attribute *name* as `invalid per syntax`, and osixia's image ships `ppolicy.la` without loading it.

Unit tests cover the status matrix, the sentinels, `pwdMaxAge` parsing, policy precedence (entry over client default) and the nil-cache path. `golangci-lint`: 0 issues. Targeted integration run (user/password/find) green in 46s; the full integration suite exceeds `go test`'s 10-minute default timeout, so it needs `-timeout` — that is pre-existing, not introduced here.

## Compatibility

Additive. New `User` fields, a new optional `Config` field, new methods. Existing callers are unaffected except that `FindUserByDN` now returns the fields it always should have.
