### PR TITLE
ci(codecov): match the unit flag name to what go-check.yml uploads

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -23,7 +23,12 @@ coverage:
         target: 100%
 
 flags:
-  unit:
+  # Must match the flag go-check.yml uploads unit coverage under, which is
+  # "unittests" (its codecov-flags default). Declaring "unit" here instead left
+  # the real upload attributed to an undeclared flag — dropped from the
+  # config-scoped patch rollup — while this declared-but-never-uploaded flag
+  # carried forward stale coverage, so unit-tested lines showed as uncovered.
+  unittests:
     paths:
       - "**/*.go"
     carryforward: true


### PR DESCRIPTION
## Problem

Unit-tested lines were reported as **uncovered** on the codecov patch status, failing the 100% patch gate for reasons unrelated to the diff. It surfaced on #186, where `PasswordExpiryStatus.String` and `PasswordExpiry.Expired` — both with dedicated unit tests, 100% covered locally — showed as uncovered.

## Cause

A flag-name mismatch between the config and the CI upload:

| | flag |
| --- | --- |
| `codecov.yml` declares | `unit` |
| `go-check.yml` uploads unit coverage under | `unittests` (its `codecov-flags` default; this repo doesn't override it) |

Two effects compounded:

- The real unit upload arrived under `unittests` — a flag the config never declared — so it was dropped from the config-scoped patch rollup.
- The declared `unit` flag, which nothing uploads to any more, kept **carrying forward stale coverage** from before the config drifted.

Confirmed against the codecov API for #186's head commit: the repo has received `unittests`, `unit` and `integration` flags historically; CI now uploads `unittests` + `integration`, but the config only knew `unit` + `integration`.

## Fix

Rename the flag `unit` → `unittests` so the declaration matches the upload.

The rest of the file is deliberately left alone. Unlike the equivalent issue in the consumer repo ([ldap-selfservice-password-changer#638](https://github.com/netresearch/ldap-selfservice-password-changer/pull/638), where deleting a stale root file was correct), here the **root file is the correct one**: its components and `ignore` list are tailored to this flat library. The `.github/codecov.yml` synced from the go-app template declares `cmd`/`internal` components that do not exist in a library, so activating it by deleting the root would be wrong. This is a one-line flag alignment, not a config swap.

No code change; CI config only.
