### PR TITLE
fix(security): clear gosec G115/G118 findings and pin toolchain go1.25.12

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -351,7 +352,7 @@ func (c *LRUCache) SetContext(ctx context.Context, key string, value any, ttl ti
 	}
 
 	// Compress large entries if enabled
-	if c.config.CompressionEnabled && entrySize > int32(c.config.CompressionThreshold) {
+	if c.config.CompressionEnabled && int64(entrySize) > int64(c.config.CompressionThreshold) {
 		if compressedValue, err := c.compressValue(value); err == nil {
 			entry.Value = compressedValue
 			entry.Compressed = true
@@ -382,7 +383,7 @@ func (c *LRUCache) SetContext(ctx context.Context, key string, value any, ttl ti
 	atomic.AddInt64(&c.stats.Sets, 1)
 
 	// Update max entries stat
-	currentEntries := int32(len(c.items))
+	currentEntries := clampInt32(len(c.items))
 	for {
 		maxEntries := atomic.LoadInt32(&c.stats.MaxEntries)
 		if currentEntries <= maxEntries || atomic.CompareAndSwapInt32(&c.stats.MaxEntries, maxEntries, currentEntries) {
@@ -536,7 +537,7 @@ func (c *LRUCache) GetWithRefresh(key string, refreshFunc func() (any, error)) (
 // Stats returns current cache statistics
 func (c *LRUCache) Stats() CacheStats {
 	c.mu.RLock()
-	totalEntries := int32(len(c.items))
+	totalEntries := clampInt32(len(c.items))
 	var negativeEntries int32
 	for _, entry := range c.items {
 		if entry.IsNegative {
@@ -679,12 +680,26 @@ func (c *LRUCache) evictForSpace(neededBytes int64) error {
 	return nil
 }
 
+// clampInt32 converts n to int32, saturating at the int32 bounds instead of
+// wrapping. Sizes and entry counts are tracked as int32 but computed as int; a
+// wrapped conversion would yield a negative size and corrupt the memory
+// accounting that drives eviction.
+func clampInt32(n int) int32 {
+	if n > math.MaxInt32 {
+		return math.MaxInt32
+	}
+	if n < math.MinInt32 {
+		return math.MinInt32
+	}
+	return int32(n)
+}
+
 // estimateEntrySize calculates approximate memory usage for a cache entry
 func (c *LRUCache) estimateEntrySize(key string, value any) int32 {
 	size := len(key) + 8 // Key string + basic overhead
 
 	if value == nil {
-		return int32(size + 16) // Base entry overhead
+		return clampInt32(size + 16) // Base entry overhead
 	}
 
 	switch v := value.(type) {
@@ -719,7 +734,7 @@ func (c *LRUCache) estimateEntrySize(key string, value any) int32 {
 		size += 256
 	}
 
-	return int32(size + 64) // Add overhead for CacheEntry struct
+	return clampInt32(size + 64) // Add overhead for CacheEntry struct
 }
 
 // compressValue compresses a value using gzip (placeholder implementation)

--- a/cache_generic.go
+++ b/cache_generic.go
@@ -266,9 +266,10 @@ func (c *GenericLRUCache[T]) Set(key string, value T, ttl time.Duration) error {
 
 	// Update stats
 	atomic.AddInt64(&c.stats.Sets, 1)
-	atomic.StoreInt32(&c.stats.TotalEntries, int32(len(c.items)))
-	if int32(len(c.items)) > atomic.LoadInt32(&c.stats.MaxEntries) {
-		atomic.StoreInt32(&c.stats.MaxEntries, int32(len(c.items)))
+	entryCount := clampInt32(len(c.items))
+	atomic.StoreInt32(&c.stats.TotalEntries, entryCount)
+	if entryCount > atomic.LoadInt32(&c.stats.MaxEntries) {
+		atomic.StoreInt32(&c.stats.MaxEntries, entryCount)
 	}
 
 	return nil
@@ -400,7 +401,7 @@ func (c *GenericLRUCache[T]) SetNegative(key string, ttl time.Duration) error {
 
 	// Update stats
 	atomic.AddInt32(&c.stats.NegativeEntries, 1)
-	atomic.StoreInt32(&c.stats.TotalEntries, int32(len(c.items)))
+	atomic.StoreInt32(&c.stats.TotalEntries, clampInt32(len(c.items)))
 
 	return nil
 }
@@ -411,7 +412,7 @@ func (c *GenericLRUCache[T]) Stats() CacheStats {
 	defer c.mu.RUnlock()
 
 	stats := c.stats
-	stats.TotalEntries = int32(len(c.items))
+	stats.TotalEntries = clampInt32(len(c.items))
 	stats.MemoryUsageBytes = atomic.LoadInt64(&c.memoryUsage)
 	stats.MemoryUsageMB = float64(stats.MemoryUsageBytes) / (1024 * 1024)
 
@@ -462,7 +463,7 @@ func (c *GenericLRUCache[T]) removeEntry(key string) {
 		if entry.IsNegative {
 			atomic.AddInt32(&c.stats.NegativeEntries, -1)
 		}
-		atomic.StoreInt32(&c.stats.TotalEntries, int32(len(c.items)))
+		atomic.StoreInt32(&c.stats.TotalEntries, clampInt32(len(c.items)))
 	}
 }
 

--- a/cache_test.go
+++ b/cache_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -946,4 +947,26 @@ func BenchmarkCacheConcurrent(b *testing.B) {
 			i++
 		}
 	})
+}
+
+func TestClampInt32(t *testing.T) {
+	tests := []struct {
+		name string
+		in   int
+		want int32
+	}{
+		{"zero", 0, 0},
+		{"typical entry size", 1234, 1234},
+		{"max int32 passes through", math.MaxInt32, math.MaxInt32},
+		{"min int32 passes through", math.MinInt32, math.MinInt32},
+		{"above max saturates", math.MaxInt32 + 1, math.MaxInt32},
+		{"far above max saturates", math.MaxInt32 * 4, math.MaxInt32},
+		{"below min saturates", math.MinInt32 - 1, math.MinInt32},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, clampInt32(tt.in))
+		})
+	}
 }

--- a/concurrency.go
+++ b/concurrency.go
@@ -105,7 +105,7 @@ func NewWorkerPool[T any](client *LDAP, config *WorkerPoolConfig) *WorkerPool[T]
 		config = DefaultWorkerPoolConfig()
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), config.Timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), config.Timeout) // #nosec G118 -- cancel is stored in WorkerPool.cancel and invoked by (*WorkerPool[T]).Close.
 
 	pool := &WorkerPool[T]{
 		workerCount: config.WorkerCount,
@@ -311,7 +311,7 @@ type PipelineStage[T, U any] struct {
 //	    fmt.Printf("Created user: %s\n", user.CN())
 //	}
 func NewPipeline[T, U any](ctx context.Context, logger *slog.Logger, bufferSize int) *Pipeline[T, U] {
-	pipelineCtx, cancel := context.WithCancel(ctx)
+	pipelineCtx, cancel := context.WithCancel(ctx) // #nosec G118 -- cancel is stored in Pipeline.cancel and invoked by (*Pipeline[T, U]).Close.
 
 	return &Pipeline[T, U]{
 		stages:    make([]PipelineStage[any, any], 0),
@@ -525,7 +525,7 @@ type FanOut[T, U any] struct {
 //	    fmt.Printf("Found user: %s\n", user.CN())
 //	}
 func NewFanOut[T, U any](ctx context.Context, logger *slog.Logger, bufferSize int) *FanOut[T, U] {
-	fanOutCtx, cancel := context.WithCancel(ctx)
+	fanOutCtx, cancel := context.WithCancel(ctx) // #nosec G118 -- cancel is stored in FanOut.cancel and invoked by (*FanOut[T, U]).Close.
 
 	return &FanOut[T, U]{
 		workers:    make([]func(context.Context, T) (U, error), 0),
@@ -676,7 +676,7 @@ type BatchProcessor[T any] struct {
 func NewBatchProcessor[T any](client *LDAP, batchSize int, timeout time.Duration,
 	processor func(context.Context, *LDAP, []T) error) *BatchProcessor[T] {
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(context.Background()) // #nosec G118 -- cancel is stored in BatchProcessor.cancel and invoked by (*BatchProcessor[T]).Close.
 
 	bp := &BatchProcessor[T]{
 		client:    client,

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/netresearch/simple-ldap-go
 
 go 1.25.0
 
+toolchain go1.25.12
+
 require (
 	github.com/go-ldap/ldap/v3 v3.4.14
 	golang.org/x/text v0.40.0


### PR DESCRIPTION
Clears the 15 open gosec findings and the govulncheck stdlib failures. Each finding was judged individually; nothing is blanket-suppressed, and the `go 1.25.0` directive is untouched so consumers are unaffected.

## G115 — integer overflow conversion int -> int32 (11 sites)

**Real, fixed: `cache.go:687` and `cache.go:722` (`estimateEntrySize`).** `size` is accumulated as an `int` across the key length plus every DN in a cached `[]User` / `[]Group`. On overflow the conversion wraps to a *negative* `CacheEntry.Size`, which `SetContext` then adds to the `int64` memoryUsage counter (`atomic.AddInt64(&c.memoryUsage, int64(entry.Size))`) — memory accounting runs backwards and `evictForSpace` stops firing. Both returns now go through a new `clampInt32` helper that saturates at the int32 bounds instead of wrapping.

**Real, fixed: `cache.go:354`.** `entrySize > int32(c.config.CompressionThreshold)` — `CompressionThreshold` is a caller-supplied `int` with no upper bound (`NewLRUCache` only corrects `<= 0`). A value above MaxInt32 wraps negative and makes the branch true for every entry. The comparison is now done in `int64`, which removes the conversion entirely rather than annotating it.

**Bounded, but routed through the same helper: the other eight sites** (`cache.go:385`, `cache.go:539`, `cache_generic.go:269-271`, `403`, `414`, `465`) all convert `len(c.items)`. A Go map with more than 2^31 live entries is not reachable in any real process, so a `#nosec` would have been defensible — but eight separate reachability justifications are worse than one helper. gosec's SSA range analysis accepts the guarded conversion inside `clampInt32`, so **G115 needs no suppression anywhere**.

### On widening the types instead

`CacheStats.TotalEntries` / `.MaxEntries` / `.NegativeEntries` and `CacheEntry.Size` are `int32`. Widening them to `int64` would delete all eleven conversions at the source, and that is the cleaner shape in the abstract. It is not done here because both types are exported: any consumer assigning these to an `int32`, or comparing against one, would stop compiling. For a library that is a breaking change out of proportion to the finding, so the conversions are made safe at the call sites instead. Flagging it explicitly in case the maintainers would rather take the break in a future major.

## G118 — context cancellation function is not called (4 sites)

All four are false positives of a purely syntactic check, verified by reading each constructor and the matching `Close`:

| Constructor | cancel stored | invoked by |
| --- | --- | --- |
| `NewWorkerPool` (`concurrency.go:108`) | `WorkerPool.cancel` (:115) | `(*WorkerPool[T]).Close` (:234) |
| `NewPipeline` (`concurrency.go:314`) | `Pipeline.cancel` (:321) | `(*Pipeline[T, U]).Close` (:485) |
| `NewFanOut` (`concurrency.go:528`) | `FanOut.cancel` (:536) | `(*FanOut[T, U]).Close` (:634) |
| `NewBatchProcessor` (`concurrency.go:679`) | `BatchProcessor.cancel` (:689) | `(*BatchProcessor[T]).Close` (:762) |

A `defer cancel()` in the constructor — gosec's suggested autofix — would cancel the context before the object is even returned. Each site gets a `#nosec G118` naming the `Close` method that owns the call.

## govulncheck — `toolchain go1.25.12`

`go.mod` gains a `toolchain` directive; the `go` directive stays at `1.25.0`, so nothing is forced on consumers (a dependency's `toolchain` line is ignored by the main module). Against the 1.25 line govulncheck reported nine reachable stdlib advisories, including GO-2026-5856 (crypto/tls), GO-2026-5037 (crypto/x509) and GO-2026-4986 / GO-2026-4977 (net/mail); under 1.25.12 it reports none. `actions/setup-go` v7 reads `toolchain` in preference to `go` when resolving `go-version-file: go.mod` (confirmed in the action's `installer.ts` and its README), so the reusable `go-check.yml` workflow will install 1.25.12.

One caveat worth knowing locally: the directive sets a *minimum*, so a developer whose local toolchain is newer keeps using it. On go1.26.0/go1.26.1 govulncheck still reports these same advisories, because the 1.26 backports only landed in 1.26.2–1.26.5. Updating to go1.26.5, or exporting `GOTOOLCHAIN=go1.25.12`, reproduces the CI result.

## Verification

Run under `GOTOOLCHAIN=go1.25.12` (what CI installs) on the final tree:

```
$ go build ./... && go vet ./...
BUILD OK
VET OK

$ go test ./... -count=1
ok  	github.com/netresearch/simple-ldap-go	58.336s
ok  	github.com/netresearch/simple-ldap-go/examples/authentication	0.003s
[... all 10 packages ok ...]

$ go run github.com/securego/gosec/v2/cmd/gosec@latest ./...
Summary:
  Gosec  : dev
  Files  : 39
  Lines  : 18355
  Nosec  : 7
  Issues : 0
GOSEC_EXIT=0

$ go run golang.org/x/vuln/cmd/govulncheck@latest ./...
No vulnerabilities found.
Your code is affected by 0 vulnerabilities.
GOVULNCHECK_EXIT=0

$ golangci-lint run ./...
0 issues.
```

`Nosec: 7` = 3 pre-existing (`security.go:1091` G402, `groups.go:134`/`:143` G115) + the 4 new G118.

`TestClampInt32` covers pass-through, both boundaries, and saturation above/below.
