### PR TITLE
feat: add NewObject constructor for Object fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `NewObject(cn, dn string) Object` ([#191](https://github.com/netresearch/simple-ldap-go/issues/191)). `Object.cn` and `Object.dn` were written only by `objectFromEntry`, so a consumer could not build a `User`, `Group` or `Computer` fixture with a DN through the public API — both downstream repos did it with reflection plus an `unsafe` write, which gosec flags as G103. A constructor rather than setters keeps the fields read-only after construction: an Object still cannot be edited to disagree with what the directory returned.
+
 ---
 
 ## [v1.13.0] - 2026-07-23

--- a/object.go
+++ b/object.go
@@ -8,6 +8,23 @@ type Object struct {
 	dn string
 }
 
+// NewObject builds an Object with the given common name and distinguished name.
+//
+// Production code never needs this: an Object is normally decoded from a
+// directory response, and its fields are unexported so that what a directory
+// returned cannot be edited afterwards. NewObject exists so that callers can
+// construct fixtures — a User, Group or Computer whose DN() and CN() answer
+// known values — without reaching into the unexported fields via reflection.
+//
+// The arguments are cn first, dn second, matching the field order; both are
+// strings, so a swapped call compiles.
+func NewObject(cn, dn string) Object {
+	return Object{
+		cn: cn,
+		dn: dn,
+	}
+}
+
 // objectFromEntry creates an Object from an LDAP entry.
 func objectFromEntry(entry *ldap.Entry) Object {
 	return Object{

--- a/object_test.go
+++ b/object_test.go
@@ -144,6 +144,97 @@ func TestObjectStructFields(t *testing.T) {
 	})
 }
 
+func TestNewObject(t *testing.T) {
+	tests := []struct {
+		name string
+		cn   string
+		dn   string
+	}{
+		{
+			name: "user distinguished name",
+			cn:   "John Doe",
+			dn:   "uid=jdoe,ou=people,dc=example,dc=com",
+		},
+		{
+			name: "empty cn",
+			cn:   "",
+			dn:   "cn=,ou=people,dc=example,dc=com",
+		},
+		{
+			name: "both empty",
+			cn:   "",
+			dn:   "",
+		},
+		{
+			name: "unicode cn",
+			cn:   "Пользователь",
+			dn:   "cn=Пользователь,ou=people,dc=example,dc=com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obj := NewObject(tt.cn, tt.dn)
+
+			assert.Equal(t, tt.cn, obj.CN())
+			assert.Equal(t, tt.dn, obj.DN())
+		})
+	}
+}
+
+func TestNewObjectMatchesObjectFromEntry(t *testing.T) {
+	entry := &ldap.Entry{
+		DN: "uid=jdoe,ou=people,dc=example,dc=com",
+		Attributes: []*ldap.EntryAttribute{
+			{
+				Name:   "cn",
+				Values: []string{"John Doe"},
+			},
+		},
+	}
+
+	assert.Equal(t, objectFromEntry(entry), NewObject("John Doe", "uid=jdoe,ou=people,dc=example,dc=com"))
+}
+
+func TestNewObjectComposesIntoFixtures(t *testing.T) {
+	t.Run("user", func(t *testing.T) {
+		user := User{
+			Object:         NewObject("Test User", "uid=testuser,ou=people,dc=example,dc=com"),
+			SAMAccountName: "testuser",
+			Enabled:        true,
+		}
+
+		assert.Equal(t, "uid=testuser,ou=people,dc=example,dc=com", user.DN())
+		assert.Equal(t, "Test User", user.CN())
+		assert.Equal(t, "testuser", user.SAMAccountName)
+		assert.True(t, user.Enabled)
+	})
+
+	t.Run("group", func(t *testing.T) {
+		group := Group{
+			Object:  NewObject("testgroup", "cn=testgroup,ou=groups,dc=example,dc=com"),
+			Members: []string{"uid=testuser,ou=people,dc=example,dc=com"},
+		}
+
+		assert.Equal(t, "cn=testgroup,ou=groups,dc=example,dc=com", group.DN())
+		assert.Equal(t, "testgroup", group.CN())
+		assert.Len(t, group.Members, 1)
+	})
+
+	t.Run("computer", func(t *testing.T) {
+		computer := Computer{
+			Object:         NewObject("TESTCOMPUTER", "cn=TESTCOMPUTER,ou=computers,dc=example,dc=com"),
+			SAMAccountName: "TESTCOMPUTER$",
+			OS:             "Windows 10 Pro",
+		}
+
+		assert.Equal(t, "cn=TESTCOMPUTER,ou=computers,dc=example,dc=com", computer.DN())
+		assert.Equal(t, "TESTCOMPUTER", computer.CN())
+		assert.Equal(t, "TESTCOMPUTER$", computer.SAMAccountName)
+		assert.Equal(t, "Windows 10 Pro", computer.OS)
+	})
+}
+
 func TestObjectInheritance(t *testing.T) {
 	// Test that structs embedding Object inherit its methods correctly
 	t.Run("user object inheritance", func(t *testing.T) {


### PR DESCRIPTION
`Object.cn` and `Object.dn` are unexported and written only by `objectFromEntry`, so a consumer cannot build a `User`, `Group` or `Computer` fixture with a DN through the public API. Both downstream repos do it with reflection plus an `unsafe` write to the unexported fields, which gosec flags as G103 now that it is blocking in the shared workflow.

```go
// NewObject builds an Object with the given common name and distinguished name.
func NewObject(cn, dn string) Object
```

## Why a constructor, and only this one

The fields are unexported on purpose — an `Object` mirrors what the directory returned, and it should not be editable afterwards into something the directory never said. Setters would give that away permanently for the sake of test fixtures. A constructor taking both values at build time does not: after `NewObject` returns, the object is as immutable as one decoded from an entry, and the only way to produce a DN that disagrees with the directory is to state it explicitly at construction, in a fixture, which is the point.

The issue left open whether `NewUser`/`NewGroup`/`NewComputer` belong here too. They don't. Every other field on those three types is already exported, so the embedded `Object` is the only part a caller cannot set, and `ldap.User{Object: ldap.NewObject(cn, dn), SAMAccountName: …}` covers the whole case with one function instead of four. Adding per-type constructors would also mean a positional or option-based mirror of every field on `User` — an API surface that has to track the struct forever, to solve a problem the struct literal already solves. Same reasoning against a separate `ldaptest` subpackage: it would be a second import path and a second thing to version for a single three-line function, and the constructor is legitimate outside tests anyway (any caller assembling an `Object` from a source that is not a `*ldap.Entry`).

The one cost is that `cn` and `dn` are both strings and adjacent, so a swapped call compiles. The argument order follows the field order and the issue's sketch, and the doc comment names it.

Additive and non-breaking: nothing existing changes behaviour or signature, and the `go 1.25.0` directive is untouched.

## Tests

`TestNewObject` covers the `DN()`/`CN()` round-trip including empty and unicode values; `TestNewObjectMatchesObjectFromEntry` asserts a constructed Object equals one decoded from the equivalent `*ldap.Entry`; `TestNewObjectComposesIntoFixtures` builds a `User`, a `Group` and a `Computer` from it and reads DN/CN back through the embedded methods.

## Follow-up, not this PR

Removing the `unsafe` from [ldap-manager `internal/ldap_cache/cachetest/helpers.go`](https://github.com/netresearch/ldap-manager/blob/main/internal/ldap_cache/cachetest/helpers.go) and [raybeam `internal/server/test_helpers_test.go`](https://github.com/netresearch/raybeam/blob/main/internal/server/test_helpers_test.go) needs a simple-ldap-go release and a dependency bump in each repo first, so it is out of scope here. ldap-manager is the one that actually gains something: its helpers are shared across two packages and so cannot live in a `_test.go` file, which is why that repo currently compiles `unsafe` into the binary behind a `#nosec` ([ldap-manager#630](https://github.com/netresearch/ldap-manager/pull/630)).

Closes #191
