### PR TITLE
ci(release): re-enable cosign signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,13 +10,6 @@ permissions: {}
 jobs:
   create:
     uses: netresearch/.github/.github/workflows/golib-create-release.yml@main
-    with:
-      # cosign 3.x on the current reusable hits
-      # "create bundle file: open : no such file or directory" —
-      # disable keyless signing until the template is fixed. GitHub
-      # artifact attestation (attest: true default) still provides
-      # provenance for every asset.
-      cosign-sign: false
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
Signing was switched off on 2026-04-21 with the note *"disable keyless signing until the template is fixed"* — cosign 3.x was failing with `create bundle file: open : no such file or directory`. The template was fixed; the workaround was not removed, so three months of releases went out without a cosign bundle, including [v1.14.0](https://github.com/netresearch/simple-ldap-go/releases/tag/v1.14.0).

**The fix is proven by a sibling repo, not assumed:** go-cron calls the same `golib-create-release.yml` with signing enabled, and its [v0.15.1](https://github.com/netresearch/go-cron/releases/tag/v0.15.1) carries `checksums.txt.sigstore.json`.

**What was *not* broken.** The removed comment also claimed GitHub artifact attestation still covered every asset, and that holds — I checked rather than assumed: `gh attestation verify` succeeds for `checksums.txt` and both SBOMs of v1.14.0. So this closes a gap in signature *coverage*, not an absence of provenance. What it restores concretely is the `.sigstore.json` file that OSSF Scorecard's signed-releases probe looks for.

The next tag carries the signature; v1.14.0 stays as published.